### PR TITLE
Docs: Add Trademark & Mandatory Attribution Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ git push origin feature/your-feature
 
 ---
 
-## 📄 License
+## 📄 License & Trademark
 
 This project is licensed under the **GNU General Public License v3 (GPLv3)**.
 
@@ -312,6 +312,11 @@ Omni Browser — Copyright (C) 2026 RebelRoot Ltd
 This is free software: you can redistribute it and/or modify it
 under the terms of the GPLv3. See LICENSE for details.
 ```
+
+> [!IMPORTANT]
+> **Forking & Redistribution Terms:**
+> Pursuant to GPLv3 Section 7(b), any derivative works, forks, or hosted versions of this software **must retain original author attribution** and link back to this repository. You **must also rebrand** the application (use your own logo and name) to respect the **[Trademark & Attribution Policy](TRADEMARK.md)**.
+
 
 ---
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,37 @@
+# 🏷️ Trademark & Attribution Policy
+
+This policy governs the branding, naming, and attribution requirements for **Omni Browser** and any derivative works, forks, or distributions based on this codebase.
+
+While the source code is licensed under the copyleft **GNU General Public License v3.0 (GPLv3)**, the copyright license does *not* grant you rights to use the project's trademarks, logos, or brand identity.
+
+---
+
+## 1. Trademark Guidelines
+
+The names **"Omni Browser"**, **"Omni"** (in the context of browser software), and **"RebelRoot"**, as well as all associated logos, icons, and graphics in this repository, are proprietary trademarks of **RebelRoot Ltd**.
+
+If you fork this repository, modify the code, or distribute a derivative version of this browser:
+*   **Must Rename:** You **must** rename the application. You cannot use "Omni Browser", "Omni", or "RebelRoot" in the name of your application, package, or distribution.
+*   **Must Rebrand:** You **must** replace all branding, icons, and official logos with your own unique visual assets before publishing or sharing.
+*   **No Endorsement:** You may not state or imply that your fork is endorsed by, affiliated with, or built in partnership with RebelRoot.
+
+---
+
+## 2. Mandatory Attribution (GPLv3 Section 7)
+
+Pursuant to **Section 7(b) of the GNU General Public License v3.0**, we require the preservation of reasonable legal notices and author attribution. 
+
+Any distribution, fork, or derivative work of this software **must** comply with the following attribution terms:
+
+1.  **Repository Link:** You must prominently display a clickable hyperlink back to the original repository (`https://github.com/REBEL-ROOT/omni-browser`) at the top of your fork's `README.md` or landing page.
+2.  **In-App Credits:** You must retain or add a visible credit in the application's "About" or "Settings" screen stating:
+    > *“Based on Omni Browser by RebelRoot (github.com/REBEL-ROOT/omni-browser)”*
+3.  **Preservation of Copyright Headers:** All copyright notices (`Copyright (C) 2026 RebelRoot Ltd`) at the top of original source files must be preserved in their entirety.
+
+---
+
+## 3. Policy Enforcement
+
+Failure to comply with either the Trademark guidelines or the Mandatory Attribution requirements constitutes a violation of the licensing terms of this repository and will result in a formal DMCA takedown request or legal trademark enforcement.
+
+For any questions regarding commercial licensing or licensing exceptions, contact us directly on our official [LinkedIn](https://www.linkedin.com/company/rebelroot).


### PR DESCRIPTION
## Trademark and Mandatory Attribution Changes

- **Added `TRADEMARK.md`:** Implements a strict trademark and branding policy. Forks of the browser cannot use the name 'Omni Browser', 'Omni', or 'RebelRoot' branding/logos.
- **Mandatory Attribution (GPLv3 Sec 7b):** Mandates that any modified code, redistribution, or network deployment must keep copyright headers, contain a link to the original repository in their README, and show credits in the 'About' screen.
- **Updated README.md:** Highlighted these requirements at the bottom of the main documentation under the License section.

These changes legally protect the brand and identity of Omni Browser while keeping the repository compliant with open-source norms.