### PR TITLE
feat: canonical bookmark model foundation (Phase 00-01)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,6 +198,8 @@ dependencies {
     // project's existing SecurityPolicyTest and the new Offline AI tests compile
     // and run under `./gradlew test`.
     testImplementation("junit:junit:4.13.2")
+    // org.json for JVM unit tests (mirrors Android's org.json API)
+    testImplementation("org.json:json:20231013")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.2")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.2")

--- a/app/src/main/java/com/rebelroot/omni/bookmarks/model/BookmarkCollection.kt
+++ b/app/src/main/java/com/rebelroot/omni/bookmarks/model/BookmarkCollection.kt
@@ -1,0 +1,374 @@
+/*
+ * Omni Browser - Canonical Bookmark Collection
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * In-memory container and operation set over the canonical bookmark model.
+ * All ordering is deterministic: positions are dense 0-based indexes within a
+ * parent. Moving a folder into its own descendant is rejected, so the model
+ * can never represent a cycle. Pure Kotlin — JVM testable.
+ */
+
+package com.rebelroot.omni.bookmarks.model
+
+import java.util.UUID
+
+/**
+ * Mutable, validated collection of bookmarks and folders.
+ *
+ * The collection is intentionally transport-agnostic: persistence (Phase 02),
+ * import (Phase 04) and export (Phase 06) are separate layers that read from
+ * and mutate through this API.
+ */
+class BookmarkCollection(
+    /** Injectable clock for deterministic tests; defaults to the wall clock. */
+    private val clock: () -> Long = System::currentTimeMillis
+) {
+
+    private val bookmarks = LinkedHashMap<String, OmniBookmark>()
+    private val folders = LinkedHashMap<String, OmniBookmarkFolder>()
+
+    // ── Reads ────────────────────────────────────────────────────────────────
+
+    fun bookmark(id: String): OmniBookmark? = bookmarks[id]
+
+    fun folder(id: String): OmniBookmarkFolder? = folders[id]
+
+    /** Leaf bookmarks directly inside [parentId], ordered by position. */
+    fun bookmarkChildren(parentId: String): List<OmniBookmark> =
+        bookmarks.values.filter { it.parentId == parentId }.sortedBy { it.position }
+
+    /** Folders directly inside [parentId], ordered by position. */
+    fun folderChildren(parentId: String): List<OmniBookmarkFolder> =
+        folders.values.filter { it.parentId == parentId }.sortedBy { it.position }
+
+    /** Total number of items (folders + bookmarks) directly inside [parentId]. */
+    fun childCount(parentId: String): Int =
+        bookmarks.values.count { it.parentId == parentId } +
+            folders.values.count { it.parentId == parentId }
+
+    /** Ids of every item inside [parentId], ordered by position (interleaved across folders and bookmarks). */
+    fun childIds(parentId: String): List<String> = mutableChildIds(parentId)
+
+    /** All bookmarks (insertion order — for storage round-trips, use the tree). */
+    fun allBookmarks(): List<OmniBookmark> = bookmarks.values.toList()
+
+    /** All folders (insertion order). */
+    fun allFolders(): List<OmniBookmarkFolder> = folders.values.toList()
+
+    fun bookmarkCount(): Int = bookmarks.size
+
+    fun folderCount(): Int = folders.size
+
+    // ── Mutations ────────────────────────────────────────────────────────────
+
+    /**
+     * Adds a leaf bookmark to [parentId] (appended at the end unless an
+     * explicit [position] is given). Duplicate URLs and duplicate titles are
+     * allowed — identity is the id, never the URL.
+     */
+    fun addBookmark(
+        title: String,
+        url: String,
+        parentId: String = ROOT_FOLDER_ID,
+        position: Long? = null
+    ): OmniBookmark {
+        requireParentExists(parentId)
+        val now = clock()
+        val entry = OmniBookmark(
+            id = UUID.randomUUID().toString(),
+            parentId = parentId,
+            position = position ?: nextPosition(parentId),
+            title = title,
+            url = url,
+            createdAt = now,
+            modifiedAt = now
+        )
+        bookmarks[entry.id] = entry
+        return entry
+    }
+
+    /**
+     * Adds a folder to [parentId] (appended at the end unless an explicit
+     * [position] is given). Folders may be empty and may nest arbitrarily.
+     */
+    fun addFolder(
+        title: String,
+        parentId: String = ROOT_FOLDER_ID,
+        position: Long? = null
+    ): OmniBookmarkFolder {
+        requireParentExists(parentId)
+        val now = clock()
+        val entry = OmniBookmarkFolder(
+            id = UUID.randomUUID().toString(),
+            parentId = parentId,
+            position = position ?: nextPosition(parentId),
+            title = title,
+            createdAt = now,
+            modifiedAt = now
+        )
+        folders[entry.id] = entry
+        return entry
+    }
+
+    /**
+     * Moves any item (bookmark or folder) to [newParentId] at [newIndex]
+     * (0-based; clamped to the valid range). Positions stay dense after the
+     * move. Moving a folder into itself or its own descendant throws
+     * [IllegalArgumentException] — the model must stay acyclic.
+     *
+     * @return false if [id] is unknown
+     */
+    fun moveItem(id: String, newParentId: String, newIndex: Int): Boolean {
+        val entry = find(id) ?: return false
+        requireParentExists(newParentId)
+
+        val isFolderEntry = entry is FolderEntry
+        if (isFolderEntry) {
+            require(newParentId != id) { "Cannot move a folder into itself" }
+            require(newParentId !in descendantsOf(id)) { "Cannot move a folder into its own descendant" }
+        }
+
+        val oldParent = entry.parentId
+        val oldSiblings = mutableChildIds(oldParent)
+        val oldIndex = oldSiblings.indexOf(id)
+        require(oldIndex >= 0) { "Item $id has no position in parent $oldParent" }
+        oldSiblings.removeAt(oldIndex)
+
+        if (oldParent == newParentId) {
+            // Final-position semantics: after removal there are n-1 siblings,
+            // so the insertion index is simply the clamped target.
+            val target = newIndex.coerceIn(0, oldSiblings.size)
+            oldSiblings.add(target, id)
+            reindex(oldSiblings, oldParent)
+        } else {
+            reindex(oldSiblings, oldParent) // origin parent lost one element
+            val newSiblings = mutableChildIds(newParentId)
+            val target = newIndex.coerceIn(0, newSiblings.size)
+            newSiblings.add(target, id)
+            setParent(id, newParentId)
+            reindex(newSiblings, newParentId)
+        }
+        touch(id)
+        return true
+    }
+
+    /**
+     * Deletes an item. Deleting a folder cascades to every descendant
+     * bookmark and subfolder. Positions of surviving siblings stay dense.
+     *
+     * @return false if [id] is unknown
+     */
+    fun deleteItem(id: String): Boolean {
+        val doomedFolderIds: Set<String>
+        val doomedBookmarkIds: Set<String>
+        if (folders.containsKey(id)) {
+            doomedFolderIds = descendantsOf(id) + id
+            doomedBookmarkIds = bookmarks.values.filter { it.parentId in doomedFolderIds }.map { it.id }.toSet()
+        } else if (bookmarks.containsKey(id)) {
+            doomedFolderIds = emptySet()
+            doomedBookmarkIds = setOf(id)
+        } else {
+            return false
+        }
+        // Every parent that loses a child must be re-indexed to stay dense.
+        val affectedParents = LinkedHashSet<String>()
+        doomedBookmarkIds.forEach { affectedParents += bookmarks[it]?.parentId ?: return@forEach }
+        doomedFolderIds.forEach { affectedParents += folders[it]?.parentId ?: return@forEach }
+        doomedFolderIds.forEach { folders.remove(it) }
+        doomedBookmarkIds.forEach { bookmarks.remove(it) }
+        affectedParents
+            .filter { it == ROOT_FOLDER_ID || folders.containsKey(it) }
+            .forEach { reindex(mutableChildIds(it), it) }
+        return true
+    }
+
+    /** Renames an item. @return false if [id] is unknown. */
+    fun rename(id: String, newTitle: String): Boolean {
+        val entry = find(id) ?: return false
+        val now = clock()
+        when (entry) {
+            is FolderEntry -> folders[id] = folders.getValue(id).copy(title = newTitle, modifiedAt = now)
+            is ItemEntry -> bookmarks[id] = bookmarks.getValue(id).copy(title = newTitle, modifiedAt = now)
+        }
+        return true
+    }
+
+    /** Updates a bookmark URL. @return false if [id] is unknown or a folder. */
+    fun setUrl(id: String, newUrl: String): Boolean {
+        val entry = bookmarks[id] ?: return false
+        bookmarks[id] = entry.copy(url = newUrl, modifiedAt = clock())
+        return true
+    }
+
+    // ── Tree ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Builds the derived tree, root first, preserving per-parent ordering.
+     * There are no allowed shared references, so a simple recursion is safe
+     * (invariant: the model is acyclic and parents always reference real ids).
+     */
+    fun buildTree(): BookmarkNode.Folder = buildChildren(ROOT_FOLDER_ID).let { children ->
+        BookmarkNode.Folder(
+            id = ROOT_FOLDER_ID,
+            parentId = "",
+            position = 0,
+            title = "",
+            createdAt = 0,
+            modifiedAt = 0,
+            children = children
+        )
+    }
+
+    private fun buildChildren(parentId: String): List<BookmarkNode> =
+        childIds(parentId).mapNotNull { id ->
+            folders[id]?.let { f ->
+                BookmarkNode.Folder(
+                    id = f.id,
+                    parentId = f.parentId,
+                    position = f.position,
+                    title = f.title,
+                    createdAt = f.createdAt,
+                    modifiedAt = f.modifiedAt,
+                    children = buildChildren(f.id)
+                )
+            } ?: bookmarks[id]?.let { b ->
+                BookmarkNode.Item(
+                    id = b.id,
+                    parentId = b.parentId,
+                    position = b.position,
+                    title = b.title,
+                    url = b.url,
+                    createdAt = b.createdAt,
+                    modifiedAt = b.modifiedAt
+                )
+            }
+        }
+
+    /**
+     * Ids of every folder nested under [folderId] (excluding [folderId]).
+     * Iterative to stay safe on very deep trees. Returns empty for an unknown id.
+     */
+    fun descendantsOf(folderId: String): Set<String> {
+        val result = LinkedHashSet<String>()
+        val stack = ArrayDeque<String>()
+        stack.addLast(folderId)
+        while (stack.isNotEmpty()) {
+            val current = stack.removeLast()
+            folders.values.forEach { f ->
+                if (f.parentId == current && result.add(f.id)) stack.addLast(f.id)
+            }
+        }
+        return result
+    }
+
+    // ── Integrity ────────────────────────────────────────────────────────────
+
+    /** Structural integrity of the current state. Empty list = valid. */
+    fun validate(): List<BookmarkValidationIssue> =
+        validate(allBookmarks(), allFolders())
+
+    // ── Storage-layer restore (migration / import / deserialization) ────────
+
+    /**
+     * Replaces the entire collection with [newBookmarks] and [newFolders]
+     * exactly as given. **Does not validate** — the storage and import layers
+     * must call [validate] on the candidate dataset first and only commit when
+     * the data is clean (fatal errors must never partially corrupt the live
+     * bookmark state). The UI never calls this.
+     */
+    fun replaceAll(newBookmarks: List<OmniBookmark>, newFolders: List<OmniBookmarkFolder>) {
+        bookmarks.clear()
+        folders.clear()
+        newBookmarks.forEach { bookmarks[it.id] = it }
+        newFolders.forEach { folders[it.id] = it }
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    private sealed interface Entry {
+        val id: String
+        val parentId: String
+    }
+
+    private data class FolderEntry(override val id: String, override val parentId: String) : Entry
+    private data class ItemEntry(override val id: String, override val parentId: String) : Entry
+
+    private fun find(id: String): Entry? =
+        folders[id]?.let { FolderEntry(it.id, it.parentId) } ?: bookmarks[id]?.let { ItemEntry(it.id, it.parentId) }
+
+    private fun requireParentExists(parentId: String) {
+        require(parentId == ROOT_FOLDER_ID || folders.containsKey(parentId)) { "Unknown parent folder $parentId" }
+    }
+
+    private fun nextPosition(parentId: String): Long = childCount(parentId).toLong()
+
+    /** Sorted ids of every item directly inside [parentId] (mutable for internal reordering). */
+    private fun mutableChildIds(parentId: String): MutableList<String> =
+        (folders.values.filter { it.parentId == parentId }.map { it.id to it.position } +
+            bookmarks.values.filter { it.parentId == parentId }.map { it.id to it.position })
+            .sortedBy { it.second }
+            .map { it.first }
+            .toMutableList()
+
+    /** Reassigns dense 0-based positions for the given items inside [parentId]. */
+    private fun reindex(ids: List<String>, parentId: String) {
+        ids.forEachIndexed { index, id ->
+            folders[id]?.let { folders[id] = it.copy(position = index.toLong()) }
+                ?: bookmarks[id]?.let { bookmarks[id] = it.copy(position = index.toLong()) }
+        }
+    }
+
+    private fun setParent(id: String, newParentId: String) {
+        folders[id]?.let { folders[id] = it.copy(parentId = newParentId) }
+            ?: bookmarks[id]?.let { bookmarks[id] = it.copy(parentId = newParentId) }
+    }
+
+    private fun touch(id: String) {
+        val now = clock()
+        folders[id]?.let { folders[id] = it.copy(modifiedAt = now) }
+            ?: bookmarks[id]?.let { bookmarks[id] = it.copy(modifiedAt = now) }
+    }
+
+    companion object {
+        /**
+         * Validates a candidate dataset **without mutating anything**. The
+         * storage and import layers use this before committing untrusted data
+         * (legacy JSON, parsed bookmark HTML) via [replaceAll].
+         */
+        fun validate(newBookmarks: List<OmniBookmark>, newFolders: List<OmniBookmarkFolder>): List<BookmarkValidationIssue> {
+            val knownFolders = newFolders.map { it.id }.toSet()
+            val issues = mutableListOf<BookmarkValidationIssue>()
+
+            fun checkEntry(id: String, parentId: String, position: Long, label: String) {
+                if (parentId != ROOT_FOLDER_ID && parentId !in knownFolders) {
+                    issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.UNKNOWN_PARENT, "$label references missing parent $parentId")
+                }
+                if (position < 0) {
+                    issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.NEGATIVE_POSITION, "$label has negative position $position")
+                }
+            }
+            newBookmarks.forEach { checkEntry(it.id, it.parentId, it.position, "bookmark") }
+            newFolders.forEach { checkEntry(it.id, it.parentId, it.position, "folder") }
+
+            // Duplicate siblings are only a problem when two items share both parent AND position.
+            val seen = mutableMapOf<Pair<String, Long>, String>()
+            (newBookmarks.map { Triple(it.id, it.parentId, it.position) } +
+                newFolders.map { Triple(it.id, it.parentId, it.position) }).forEach { (id, parent, pos) ->
+                val previous = seen.put(parent to pos, id)
+                if (previous != null) {
+                    issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.DUPLICATE_POSITION, "items $previous and $id share parent $parent position $pos")
+                }
+            }
+            return issues
+        }
+    }
+}
+
+/** A structural integrity problem found by [BookmarkCollection.validate]. */
+data class BookmarkValidationIssue(
+    val id: String,
+    val kind: Kind,
+    val message: String
+) {
+    enum class Kind { UNKNOWN_PARENT, NEGATIVE_POSITION, DUPLICATE_POSITION }
+}

--- a/app/src/main/java/com/rebelroot/omni/bookmarks/model/BookmarkCollection.kt
+++ b/app/src/main/java/com/rebelroot/omni/bookmarks/model/BookmarkCollection.kt
@@ -336,27 +336,179 @@ class BookmarkCollection(
          * (legacy JSON, parsed bookmark HTML) via [replaceAll].
          */
         fun validate(newBookmarks: List<OmniBookmark>, newFolders: List<OmniBookmarkFolder>): List<BookmarkValidationIssue> {
-            val knownFolders = newFolders.map { it.id }.toSet()
             val issues = mutableListOf<BookmarkValidationIssue>()
+            val allIds = mutableSetOf<String>()
+            val knownFolders = newFolders.map { it.id }.toMutableSet()
 
-            fun checkEntry(id: String, parentId: String, position: Long, label: String) {
-                if (parentId != ROOT_FOLDER_ID && parentId !in knownFolders) {
-                    issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.UNKNOWN_PARENT, "$label references missing parent $parentId")
+            // ── ID validation (bookmarks) ──────────────────────────────────
+            newBookmarks.forEach { b ->
+                if (b.id.isBlank()) {
+                    issues += BookmarkValidationIssue(b.id, BookmarkValidationIssue.Kind.EMPTY_ID, "bookmark has empty id")
+                    return@forEach
                 }
-                if (position < 0) {
-                    issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.NEGATIVE_POSITION, "$label has negative position $position")
+                if (b.id == ROOT_FOLDER_ID) {
+                    issues += BookmarkValidationIssue(b.id, BookmarkValidationIssue.Kind.RESERVED_ROOT_ID, "bookmark uses reserved root id")
+                }
+                if (!allIds.add(b.id)) {
+                    issues += BookmarkValidationIssue(b.id, BookmarkValidationIssue.Kind.DUPLICATE_ID, "duplicate id $b.id across bookmarks and folders")
                 }
             }
-            newBookmarks.forEach { checkEntry(it.id, it.parentId, it.position, "bookmark") }
-            newFolders.forEach { checkEntry(it.id, it.parentId, it.position, "folder") }
 
-            // Duplicate siblings are only a problem when two items share both parent AND position.
-            val seen = mutableMapOf<Pair<String, Long>, String>()
-            (newBookmarks.map { Triple(it.id, it.parentId, it.position) } +
-                newFolders.map { Triple(it.id, it.parentId, it.position) }).forEach { (id, parent, pos) ->
-                val previous = seen.put(parent to pos, id)
-                if (previous != null) {
-                    issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.DUPLICATE_POSITION, "items $previous and $id share parent $parent position $pos")
+            // ── ID validation (folders) ────────────────────────────────────
+            newFolders.forEach { f ->
+                if (f.id.isBlank()) {
+                    issues += BookmarkValidationIssue(f.id, BookmarkValidationIssue.Kind.EMPTY_ID, "folder has empty id")
+                    return@forEach
+                }
+                if (f.id == ROOT_FOLDER_ID) {
+                    issues += BookmarkValidationIssue(f.id, BookmarkValidationIssue.Kind.RESERVED_ROOT_ID, "folder uses reserved root id")
+                }
+                if (!allIds.add(f.id)) {
+                    issues += BookmarkValidationIssue(f.id, BookmarkValidationIssue.Kind.DUPLICATE_ID, "duplicate id ${f.id} across bookmarks and folders")
+                }
+            }
+
+            // ── Parent/type/position/timestamp validation (bookmarks) ─────
+            newBookmarks.forEach { b ->
+                validateParent(b.id, b.parentId, "bookmark", b, issues, knownFolders)
+                if (b.position < 0) {
+                    issues += BookmarkValidationIssue(b.id, BookmarkValidationIssue.Kind.NEGATIVE_POSITION, "bookmark has negative position ${b.position}")
+                }
+                validateTimestamps(b.id, b.createdAt, b.modifiedAt, "bookmark", issues)
+            }
+
+            // ── Parent/type/position/timestamp validation (folders) ───────
+            newFolders.forEach { f ->
+                validateParent(f.id, f.parentId, "folder", f, issues, knownFolders)
+                if (f.position < 0) {
+                    issues += BookmarkValidationIssue(f.id, BookmarkValidationIssue.Kind.NEGATIVE_POSITION, "folder has negative position ${f.position}")
+                }
+                validateTimestamps(f.id, f.createdAt, f.modifiedAt, "folder", issues)
+            }
+
+            // ── Position density (fatal) ───────────────────────────────────
+            issues += computePositionDensityIssues(newBookmarks, newFolders)
+
+            // ── Cycle detection (fatal) ────────────────────────────────────
+            issues += computeCycleIssues(newFolders)
+
+            return issues
+        }
+
+        private fun validateParent(
+            id: String, parentId: String, label: String,
+            entity: Any, issues: MutableList<BookmarkValidationIssue>, knownFolders: Set<String>
+        ) {
+            if (parentId == id) {
+                issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.SELF_PARENT, "$label is its own parent")
+                return
+            }
+            if (parentId != ROOT_FOLDER_ID && parentId !in knownFolders) {
+                issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.UNKNOWN_PARENT, "$label references missing parent $parentId")
+            }
+            // Bookmarks must not be parented to a bookmark.
+            if (label == "bookmark" && entity is OmniBookmark && entity.parentId != ROOT_FOLDER_ID && entity.parentId !in knownFolders) {
+                // Already caught as UNKNOWN_PARENT; no extra issue needed.
+            }
+        }
+
+        private fun validateTimestamps(
+            id: String, createdAt: Long, modifiedAt: Long,
+            label: String, issues: MutableList<BookmarkValidationIssue>
+        ) {
+            // Future upper bound: year 2100
+            val maxTs = 4_102_444_800_000L
+            if (createdAt < 0 || createdAt > maxTs) {
+                issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.TIMESTAMP_OUT_OF_RANGE, "$label createdAt $createdAt out of sensible range")
+            }
+            if (modifiedAt < 0 || modifiedAt > maxTs) {
+                issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.TIMESTAMP_OUT_OF_RANGE, "$label modifiedAt $modifiedAt out of sensible range")
+            }
+            if (createdAt > modifiedAt) {
+                issues += BookmarkValidationIssue(id, BookmarkValidationIssue.Kind.TIMESTAMP_REVERSED, "$label createdAt $createdAt > modifiedAt $modifiedAt")
+            }
+        }
+
+        private fun computePositionDensityIssues(
+            newBookmarks: List<OmniBookmark>,
+            newFolders: List<OmniBookmarkFolder>
+        ): List<BookmarkValidationIssue> {
+            val issues = mutableListOf<BookmarkValidationIssue>()
+            val itemsByParent = mutableMapOf<String, MutableSet<Long>>()
+
+            fun record(parent: String, pos: Long) {
+                itemsByParent.getOrPut(parent) { mutableSetOf() }.add(pos)
+            }
+            newBookmarks.forEach { record(it.parentId, it.position) }
+            newFolders.forEach { record(it.parentId, it.position) }
+
+            itemsByParent.forEach { (parent, positions) ->
+                if (positions.isEmpty()) return@forEach
+                val sorted = positions.sorted()
+                val childCount = newBookmarks.count { it.parentId == parent } +
+                    newFolders.count { it.parentId == parent }
+
+                // Must start at 0.
+                if (sorted.first() != 0L) {
+                    issues += BookmarkValidationIssue(
+                        parent,
+                        BookmarkValidationIssue.Kind.NON_DENSE_POSITION,
+                        "parent $parent positions do not start at 0 (first=${sorted.first()})"
+                    )
+                } else {
+                    // Must be dense: every value 0..max must exist.
+                    val expected = (0L until sorted.size.toLong()).toSet()
+                    if (sorted.toSet() != expected) {
+                        issues += BookmarkValidationIssue(
+                            parent,
+                            BookmarkValidationIssue.Kind.NON_DENSE_POSITION,
+                            "parent $parent positions are not dense 0..${sorted.size - 1} (actual=$sorted)"
+                        )
+                    }
+                }
+                // Duplicate detection: size mismatch means duplicates.
+                if (sorted.size != childCount) {
+                    issues += BookmarkValidationIssue(
+                        parent,
+                        BookmarkValidationIssue.Kind.DUPLICATE_POSITION,
+                        "parent $parent has duplicate positions ($childCount children, ${sorted.size} unique positions)"
+                    )
+                }
+            }
+            return issues
+        }
+
+        private fun computeCycleIssues(newFolders: List<OmniBookmarkFolder>): List<BookmarkValidationIssue> {
+            val issues = mutableListOf<BookmarkValidationIssue>()
+            val parentOf = newFolders.associate { it.id to it.parentId }
+            val knownIds = newFolders.map { it.id }.toSet()
+
+            for (folder in newFolders) {
+                if (folder.parentId == ROOT_FOLDER_ID) continue
+                if (folder.parentId == folder.id) continue // already SELF_PARENT
+                if (folder.parentId !in knownIds) continue // already UNKNOWN_PARENT
+
+                // Walk ancestors.
+                val visited = mutableSetOf<String>()
+                var current = folder.parentId
+                while (current != ROOT_FOLDER_ID && current in knownIds) {
+                    if (!visited.add(current)) {
+                        issues += BookmarkValidationIssue(
+                            folder.id,
+                            BookmarkValidationIssue.Kind.PARENT_CYCLE,
+                            "folder ${folder.id} is part of a parent cycle involving ancestor $current"
+                        )
+                        break
+                    }
+                    current = parentOf[current] ?: break
+                    if (current == folder.id) {
+                        issues += BookmarkValidationIssue(
+                            folder.id,
+                            BookmarkValidationIssue.Kind.PARENT_CYCLE,
+                            "folder ${folder.id} is its own ancestor (cycle)"
+                        )
+                        break
+                    }
                 }
             }
             return issues
@@ -370,5 +522,17 @@ data class BookmarkValidationIssue(
     val kind: Kind,
     val message: String
 ) {
-    enum class Kind { UNKNOWN_PARENT, NEGATIVE_POSITION, DUPLICATE_POSITION }
+    enum class Kind {
+        EMPTY_ID,
+        DUPLICATE_ID,
+        RESERVED_ROOT_ID,
+        UNKNOWN_PARENT,
+        SELF_PARENT,
+        PARENT_CYCLE,
+        NEGATIVE_POSITION,
+        DUPLICATE_POSITION,
+        NON_DENSE_POSITION,
+        TIMESTAMP_OUT_OF_RANGE,
+        TIMESTAMP_REVERSED
+    }
 }

--- a/app/src/main/java/com/rebelroot/omni/bookmarks/model/BookmarkNode.kt
+++ b/app/src/main/java/com/rebelroot/omni/bookmarks/model/BookmarkNode.kt
@@ -1,0 +1,44 @@
+/*
+ * Omni Browser - Canonical Bookmark Tree Nodes
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Derived tree view of the canonical bookmark model. The stored model is flat
+ * (id + parentId + position); this sealed hierarchy is what UI and exporters
+ * consume. Pure Kotlin — JVM testable.
+ */
+
+package com.rebelroot.omni.bookmarks.model
+
+/**
+ * A node in the derived bookmark tree.
+ */
+sealed interface BookmarkNode {
+    val id: String
+    val parentId: String
+    val position: Long
+    val title: String
+    val createdAt: Long
+    val modifiedAt: Long
+
+    /** A folder node; [children] are ordered by position. */
+    data class Folder(
+        override val id: String,
+        override val parentId: String,
+        override val position: Long,
+        override val title: String,
+        override val createdAt: Long,
+        override val modifiedAt: Long,
+        val children: List<BookmarkNode>
+    ) : BookmarkNode
+
+    /** A leaf bookmark node. */
+    data class Item(
+        override val id: String,
+        override val parentId: String,
+        override val position: Long,
+        override val title: String,
+        val url: String,
+        override val createdAt: Long,
+        override val modifiedAt: Long
+    ) : BookmarkNode
+}

--- a/app/src/main/java/com/rebelroot/omni/bookmarks/model/OmniBookmark.kt
+++ b/app/src/main/java/com/rebelroot/omni/bookmarks/model/OmniBookmark.kt
@@ -1,0 +1,61 @@
+/*
+ * Omni Browser - Canonical Bookmark Model
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * The canonical bookmark data model. This is the sync-ready foundation that
+ * import/export and future Omni Sync build on. It intentionally mirrors the
+ * shape used by mainstream browsers (stable string ID + parent ID + position)
+ * so browser interoperability is a representation problem, not a model problem.
+ *
+ * This file is pure Kotlin — no Android dependencies — so the model is fully
+ * unit-testable on the JVM.
+ */
+
+package com.rebelroot.omni.bookmarks.model
+
+/**
+ * Sentinel id of the implicit root folder. The root is not stored as a folder
+ * entry; any bookmark/folder whose [parentId] equals this lives at the top
+ * level of the bookmark tree.
+ */
+const val ROOT_FOLDER_ID: String = "root"
+
+/**
+ * A leaf bookmark.
+ *
+ * @param id stable, unique entity id (UUID string) — the future sync identity
+ * @param parentId id of the containing folder, or [ROOT_FOLDER_ID]
+ * @param position deterministic ordering index within the parent (0-based, dense)
+ * @param title display title (may be empty, may duplicate other titles)
+ * @param url the bookmark target (may duplicate other URLs)
+ * @param createdAt epoch millis of creation
+ * @param modifiedAt epoch millis of last modification
+ */
+data class OmniBookmark(
+    val id: String,
+    val parentId: String,
+    val position: Long,
+    val title: String,
+    val url: String,
+    val createdAt: Long,
+    val modifiedAt: Long
+)
+
+/**
+ * A bookmark folder (may be nested arbitrarily, may be empty).
+ *
+ * @param id stable, unique entity id (UUID string)
+ * @param parentId id of the containing folder, or [ROOT_FOLDER_ID]
+ * @param position deterministic ordering index within the parent (0-based, dense)
+ * @param title folder name (may be empty)
+ * @param createdAt epoch millis of creation
+ * @param modifiedAt epoch millis of last modification
+ */
+data class OmniBookmarkFolder(
+    val id: String,
+    val parentId: String,
+    val position: Long,
+    val title: String,
+    val createdAt: Long,
+    val modifiedAt: Long
+)

--- a/app/src/main/java/com/rebelroot/omni/bookmarks/parser/NetscapeBookmarkParser.kt
+++ b/app/src/main/java/com/rebelroot/omni/bookmarks/parser/NetscapeBookmarkParser.kt
@@ -1,0 +1,212 @@
+/*
+ * Omni Browser - Netscape Bookmark HTML Parser
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Parses the standard Netscape Bookmark HTML format produced by Chrome,
+ * Firefox, Edge, Safari, Brave and Opera. The parser is non-executable,
+ * operates entirely locally, and never visits URLs.
+ *
+ * This is a hand-written parser rather than an HTML DOM parser because:
+ * 1. Bookmark HTML is a very constrained subset (DL/DT/H3/A only)
+ * 2. We need to control recursion depth and attribute size limits
+ * 3. We must not pull in heavy dependencies
+ * 4. The format is simple enough for a state machine
+ *
+ * Pure Kotlin — no Android dependencies.
+ */
+
+package com.rebelroot.omni.bookmarks.parser
+
+import com.rebelroot.omni.bookmarks.model.BookmarkCollection
+import com.rebelroot.omni.bookmarks.model.ROOT_FOLDER_ID
+import java.net.URLDecoder
+import java.util.UUID
+
+/** Maximum nesting depth to prevent stack overflow on malicious input. */
+private const val MAX_DEPTH = 100
+
+/** Maximum attribute length to prevent memory exhaustion. */
+private const val MAX_ATTR_LENGTH = 10_000
+
+/** Maximum file size to parse (10 MB). */
+private const val MAX_FILE_SIZE = 10 * 1024 * 1024
+
+/**
+ * Result of parsing a Netscape Bookmark HTML file.
+ */
+data class BookmarkHtmlParseResult(
+    val collection: BookmarkCollection,
+    val warnings: List<ParseWarning>,
+    val importedBookmarks: Int,
+    val importedFolders: Int,
+    val skippedEntries: Int
+) {
+    val totalEntries: Int get() = importedBookmarks + importedFolders + skippedEntries
+}
+
+/**
+ * A non-fatal warning produced during parsing.
+ */
+data class ParseWarning(
+    val line: Int,
+    val message: String
+)
+
+/**
+ * Parses a Netscape Bookmark HTML string and returns a [BookmarkCollection].
+ *
+ * @param html the raw HTML string
+ * @param clock injectable clock for tests; defaults to System.currentTimeMillis
+ * @return parse result containing the collection and any warnings
+ * @throws ParseException on fatal errors (excessive depth, file too large, etc.)
+ */
+fun parseNetscapeBookmarkHtml(
+    html: String,
+    clock: () -> Long = System::currentTimeMillis
+): BookmarkHtmlParseResult {
+    if (html.length > MAX_FILE_SIZE) {
+        throw ParseException("File exceeds maximum size of $MAX_FILE_SIZE bytes")
+    }
+
+    val collection = BookmarkCollection(clock)
+    val warnings = mutableListOf<ParseWarning>()
+    var skippedEntries = 0
+
+    // Stack of folder IDs representing the current nesting path.
+    // Starts with root.
+    val folderStack = mutableListOf(ROOT_FOLDER_ID)
+    var currentPosition = mutableMapOf<String, Long>()
+    var depth = 0
+
+    // Simple line-by-line state machine.
+    val lines = html.lines()
+    var lineNum = 0
+
+    for (rawLine in lines) {
+        lineNum++
+        val line = rawLine.trim()
+        if (line.isEmpty()) continue
+
+        // Detect <DL> (start folder contents)
+        if (line.contains("<dl", ignoreCase = true)) {
+            depth++
+            if (depth > MAX_DEPTH) {
+                throw ParseException("Exceeded maximum nesting depth of $MAX_DEPTH at line $lineNum")
+            }
+            continue
+        }
+
+        // Detect </DL> (end folder contents)
+        if (line.contains("</dl", ignoreCase = true)) {
+            if (folderStack.size > 1) {
+                folderStack.removeAt(folderStack.size - 1)
+            }
+            depth = (depth - 1).coerceAtLeast(0)
+            continue
+        }
+
+        // Detect <DT><H3...> (folder)
+        if (line.contains("<h3", ignoreCase = true)) {
+            val folderTitle = extractTextContent(line, "h3")
+            val folder = collection.addFolder(
+                title = folderTitle,
+                parentId = folderStack.last()
+            )
+            folderStack.add(folder.id)
+            continue
+        }
+
+        // Detect <DT><A...> (bookmark)
+        if (line.contains("<a", ignoreCase = true) && line.contains("href", ignoreCase = true)) {
+            val url = extractHref(line, lineNum, warnings)
+            val title = extractTextContent(line, "a")
+
+            if (url != null && isValidUrl(url)) {
+                collection.addBookmark(
+                    title = title.ifEmpty { url },
+                    url = url,
+                    parentId = folderStack.last()
+                )
+            } else {
+                skippedEntries++
+                warnings.add(ParseWarning(lineNum, "Skipped invalid or malformed URL: ${url ?: "null"}"))
+            }
+            continue
+        }
+    }
+
+    return BookmarkHtmlParseResult(
+        collection = collection,
+        warnings = warnings,
+        importedBookmarks = collection.bookmarkCount(),
+        importedFolders = collection.folderCount(),
+        skippedEntries = skippedEntries
+    )
+}
+
+/**
+ * Extracts the text content between an opening and closing tag.
+ * Handles basic HTML entities.
+ */
+private fun extractTextContent(line: String, tag: String): String {
+    val openPattern = "<$tag[^>]*>"
+    val closePattern = "</$tag>"
+
+    val openMatch = openPattern.toRegex(RegexOption.IGNORE_CASE).find(line)
+    val closeMatch = closePattern.toRegex(RegexOption.IGNORE_CASE).find(line)
+
+    if (openMatch != null && closeMatch != null) {
+        val start = openMatch.range.last + 1
+        val end = closeMatch.range.first
+        if (start < end) {
+            return decodeHtmlEntities(line.substring(start, end).trim())
+        }
+    }
+    return ""
+}
+
+/**
+ * Extracts the href attribute from an <A> tag.
+ */
+private fun extractHref(line: String, lineNum: Int, warnings: MutableList<ParseWarning>): String? {
+    val hrefPattern = "href=[\"']([^\"']*)[\"']".toRegex(RegexOption.IGNORE_CASE)
+    val match = hrefPattern.find(line)
+    return match?.groupValues?.get(1)?.let { href ->
+        if (href.length > MAX_ATTR_LENGTH) {
+            warnings.add(ParseWarning(lineNum, "href attribute exceeds maximum length, truncating"))
+            href.take(MAX_ATTR_LENGTH)
+        } else {
+            href
+        }
+    }
+}
+
+/**
+ * Decodes common HTML entities.
+ */
+private fun decodeHtmlEntities(text: String): String {
+    return text
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+}
+
+/**
+ * Basic URL validation. Accepts http, https, and a few other common schemes.
+ */
+private fun isValidUrl(url: String): Boolean {
+    if (url.isBlank()) return false
+    val lower = url.lowercase()
+    // Reject javascript:, data:, vbscript: and other dangerous schemes
+    val dangerousSchemes = listOf("javascript:", "data:", "vbscript:", "file:", "about:")
+    if (dangerousSchemes.any { lower.startsWith(it) }) return false
+    return true
+}
+
+/**
+ * Thrown when parsing cannot continue safely.
+ */
+class ParseException(message: String) : Exception(message)

--- a/app/src/main/java/com/rebelroot/omni/bookmarks/storage/BookmarkStorage.kt
+++ b/app/src/main/java/com/rebelroot/omni/bookmarks/storage/BookmarkStorage.kt
@@ -1,0 +1,227 @@
+/*
+ * Omni Browser - Bookmark Storage (v2)
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Atomic, versioned, JSON-backed persistence for the canonical bookmark model.
+ * Writes go to a temp file and are renamed atomically so a crash during write
+ * can never corrupt the live database. The legacy flat format is detected and
+ * migrated automatically on first load.
+ *
+ * This is an Android-dependent layer (File, Context) — tests use Robolectric
+ * or instrumented tests if Android APIs are required. Pure-Kotlin tests
+ * exercise the serialization round-trip via BookmarkCollection.
+ */
+
+package com.rebelroot.omni.bookmarks.storage
+
+import android.content.Context
+import com.rebelroot.omni.bookmarks.model.*
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+
+/** JVM/Android compatible logger. On Android this is a no-op wrapper around android.util.Log
+ *  that is replaced at link time; in unit tests it falls back to System.err. */
+private object OmniLog {
+    fun w(tag: String, msg: String) {
+        try {
+            android.util.Log.w(tag, msg)
+        } catch (e: RuntimeException) {
+            System.err.println("W/$tag: $msg")
+        }
+    }
+    fun e(tag: String, msg: String, th: Throwable? = null) {
+        try {
+            if (th != null) android.util.Log.e(tag, msg, th) else android.util.Log.e(tag, msg)
+        } catch (e: RuntimeException) {
+            System.err.println("E/$tag: $msg")
+            th?.printStackTrace()
+        }
+    }
+    fun i(tag: String, msg: String) {
+        try {
+            android.util.Log.i(tag, msg)
+        } catch (e: RuntimeException) {
+            System.err.println("I/$tag: $msg")
+        }
+    }
+}
+
+private const val TAG = "BookmarkStorage"
+private const val V2_FILE = "browser_bookmarks_v2.json"
+private const val LEGACY_FILE = "browser_bookmarks.json"
+private const val SCHEMA_VERSION = 2
+
+
+/**
+ * Loads bookmarks from v2 storage, falling back to legacy migration if needed.
+ * Returns a populated [BookmarkCollection] (empty if nothing exists).
+ *
+ * Threading: caller must ensure this runs off the main thread (IO dispatcher).
+ */
+fun loadBookmarks(context: Context): BookmarkCollection =
+    loadBookmarksFromDir(context.filesDir)
+
+/**
+ * Saves the entire [BookmarkCollection] atomically to v2 storage.
+ *
+ * Threading: caller must ensure this runs off the main thread (IO dispatcher).
+ */
+fun saveBookmarks(context: Context, collection: BookmarkCollection) {
+    saveBookmarksToDir(context.filesDir, collection)
+}
+
+/**
+ * Loads bookmarks from [filesDir]. Exposed for unit tests that pass a temp directory.
+ */
+internal fun loadBookmarksFromDir(filesDir: File): BookmarkCollection {
+    val collection = BookmarkCollection()
+    val v2File = File(filesDir, V2_FILE)
+    val legacyFile = File(filesDir, LEGACY_FILE)
+
+    if (v2File.exists()) {
+        try {
+            val json = JSONObject(v2File.readText())
+            val version = json.optInt("schema_version", 1)
+            if (version >= 2) {
+                parseV2(json, collection)
+            } else {
+                OmniLog.w(TAG, "Unknown schema version $version, treating as empty")
+            }
+        } catch (e: Exception) {
+            OmniLog.e(TAG, "Error loading v2 bookmarks", e)
+        }
+    } else if (legacyFile.exists()) {
+        try {
+            migrateLegacy(legacyFile, collection)
+            // Persist the migrated data immediately so legacy is no longer needed.
+            saveBookmarksToDir(filesDir, collection)
+        } catch (e: Exception) {
+            OmniLog.e(TAG, "Error migrating legacy bookmarks", e)
+        }
+    }
+    return collection
+}
+
+/**
+ * Saves [collection] to [filesDir] atomically. Exposed for unit tests.
+ */
+internal fun saveBookmarksToDir(filesDir: File, collection: BookmarkCollection) {
+    val v2File = File(filesDir, V2_FILE)
+    val tempFile = File(filesDir, "$V2_FILE.tmp")
+    try {
+        val json = serializeV2(collection)
+        tempFile.writeText(json.toString())
+        // Atomic rename: delete destination first so rename always succeeds on overwrite.
+        if (v2File.exists() && !v2File.delete()) {
+            throw IllegalStateException("Failed to delete existing $V2_FILE before rename")
+        }
+
+        if (!tempFile.renameTo(v2File)) {
+            throw IllegalStateException("Failed to rename temp file to $V2_FILE")
+        }
+    } catch (e: Exception) {
+        OmniLog.e(TAG, "Error saving bookmarks: ${e.message}", e)
+        // Clean up temp file on failure.
+        tempFile.delete()
+    }
+}
+
+// ── Serialization ──────────────────────────────────────────────────────────
+
+private fun serializeV2(collection: BookmarkCollection): JSONObject {
+    val bookmarksArray = JSONArray()
+    collection.allBookmarks().forEach { b ->
+        bookmarksArray.put(JSONObject().apply {
+            put("id", b.id)
+            put("parentId", b.parentId)
+            put("position", b.position)
+            put("title", b.title)
+            put("url", b.url)
+            put("createdAt", b.createdAt)
+            put("modifiedAt", b.modifiedAt)
+        })
+    }
+    val foldersArray = JSONArray()
+    collection.allFolders().forEach { f ->
+        foldersArray.put(JSONObject().apply {
+            put("id", f.id)
+            put("parentId", f.parentId)
+            put("position", f.position)
+            put("title", f.title)
+            put("createdAt", f.createdAt)
+            put("modifiedAt", f.modifiedAt)
+        })
+    }
+    return JSONObject().apply {
+        put("schema_version", SCHEMA_VERSION)
+        put("bookmarks", bookmarksArray)
+        put("folders", foldersArray)
+    }
+}
+
+private fun parseV2(json: JSONObject, collection: BookmarkCollection) {
+    val bookmarks = mutableListOf<OmniBookmark>()
+    val folders = mutableListOf<OmniBookmarkFolder>()
+
+    val bookmarksArray = json.optJSONArray("bookmarks") ?: JSONArray()
+    for (i in 0 until bookmarksArray.length()) {
+        val obj = bookmarksArray.getJSONObject(i)
+        bookmarks.add(
+            OmniBookmark(
+                id = obj.getString("id"),
+                parentId = obj.getString("parentId"),
+                position = obj.getLong("position"),
+                title = obj.getString("title"),
+                url = obj.getString("url"),
+                createdAt = obj.getLong("createdAt"),
+                modifiedAt = obj.getLong("modifiedAt")
+            )
+        )
+    }
+
+    val foldersArray = json.optJSONArray("folders") ?: JSONArray()
+    for (i in 0 until foldersArray.length()) {
+        val obj = foldersArray.getJSONObject(i)
+        folders.add(
+            OmniBookmarkFolder(
+                id = obj.getString("id"),
+                parentId = obj.getString("parentId"),
+                position = obj.getLong("position"),
+                title = obj.getString("title"),
+                createdAt = obj.getLong("createdAt"),
+                modifiedAt = obj.getLong("modifiedAt")
+            )
+        )
+    }
+
+    // Validate before committing — if the stored data is corrupt, start fresh.
+    val issues = BookmarkCollection.validate(bookmarks, folders)
+    if (issues.isNotEmpty()) {
+        OmniLog.w(TAG, "Stored bookmark data is corrupt (${issues.size} issues), starting fresh: ${issues.first().message}")
+        return
+    }
+    collection.replaceAll(bookmarks, folders)
+}
+
+// ── Legacy Migration ───────────────────────────────────────────────────────
+
+/**
+ * Reads the legacy flat JSON file and populates the collection with all
+ * bookmarks at the root level (no folders). Each bookmark gets a fresh
+ * stable UUID and a dense position.
+ */
+private fun migrateLegacy(legacyFile: File, collection: BookmarkCollection) {
+    val jsonArray = JSONArray(legacyFile.readText())
+    for (i in 0 until jsonArray.length()) {
+        val obj = jsonArray.getJSONObject(i)
+        collection.addBookmark(
+            title = obj.getString("title"),
+            url = obj.getString("url"),
+            parentId = ROOT_FOLDER_ID,
+            position = i.toLong()
+        )
+    }
+    OmniLog.i(TAG, "Migrated ${jsonArray.length()} legacy bookmarks to v2")
+}

--- a/app/src/test/java/com/rebelroot/omni/bookmarks/model/BookmarkCollectionHardeningTest.kt
+++ b/app/src/test/java/com/rebelroot/omni/bookmarks/model/BookmarkCollectionHardeningTest.kt
@@ -1,0 +1,554 @@
+/*
+ * Omni Browser - Canonical Bookmark Model Hardening Tests
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Phase 01 hardening gate: invariant validation, ordering, property tests.
+ * Tests are grouped by the hardening requirements document.
+ */
+
+package com.rebelroot.omni.bookmarks.model
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class BookmarkCollectionHardeningTest {
+
+    private fun newCollection() = BookmarkCollection { 1_000_000L }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // 1. VALIDATION TESTS — Malformed candidate datasets
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun validate_emptyId_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.EMPTY_ID })
+    }
+
+    @Test
+    fun validate_reservedRootId_detectedInBookmark() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark(ROOT_FOLDER_ID, ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.RESERVED_ROOT_ID })
+    }
+
+    @Test
+    fun validate_reservedRootId_detectedInFolder() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = emptyList(),
+            newFolders = listOf(OmniBookmarkFolder(ROOT_FOLDER_ID, ROOT_FOLDER_ID, 0, "F", 1, 1))
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.RESERVED_ROOT_ID })
+    }
+
+    @Test
+    fun validate_duplicateId_acrossBookmarkAndFolder() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("dup", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1)),
+            newFolders = listOf(OmniBookmarkFolder("dup", ROOT_FOLDER_ID, 1, "F", 1, 1))
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.DUPLICATE_ID })
+    }
+
+    @Test
+    fun validate_unknownParent_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", "missing", 0, "A", "https://a.example", 1, 1)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.UNKNOWN_PARENT })
+    }
+
+    @Test
+    fun validate_negativePosition_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, -1, "A", "https://a.example", 1, 1)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.NEGATIVE_POSITION })
+    }
+
+    @Test
+    fun validate_duplicatePosition_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(
+                OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1),
+                OmniBookmark("b2", ROOT_FOLDER_ID, 0, "B", "https://b.example", 1, 1)
+            ),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.DUPLICATE_POSITION })
+    }
+
+    @Test
+    fun validate_positionGaps_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(
+                OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1),
+                OmniBookmark("b2", ROOT_FOLDER_ID, 2, "B", "https://b.example", 1, 1)
+            ),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.NON_DENSE_POSITION })
+    }
+
+    @Test
+    fun validate_positionStartingAtOne_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(
+                OmniBookmark("b1", ROOT_FOLDER_ID, 1, "A", "https://a.example", 1, 1)
+            ),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.NON_DENSE_POSITION })
+    }
+
+    @Test
+    fun validate_selfParentingFolder_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = emptyList(),
+            newFolders = listOf(OmniBookmarkFolder("f1", "f1", 0, "F", 1, 1))
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.SELF_PARENT })
+    }
+
+    @Test
+    fun validate_cycle_aToB_bToA_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = emptyList(),
+            newFolders = listOf(
+                OmniBookmarkFolder("f1", "f2", 0, "A", 1, 1),
+                OmniBookmarkFolder("f2", "f1", 0, "B", 1, 1)
+            )
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.PARENT_CYCLE })
+    }
+
+    @Test
+    fun validate_cycle_threeDeep_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = emptyList(),
+            newFolders = listOf(
+                OmniBookmarkFolder("f1", "f2", 0, "A", 1, 1),
+                OmniBookmarkFolder("f2", "f3", 0, "B", 1, 1),
+                OmniBookmarkFolder("f3", "f1", 0, "C", 1, 1)
+            )
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.PARENT_CYCLE })
+    }
+
+    @Test
+    fun validate_bookmarkParentedToBookmark_detectedAsUnknownParent() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(
+                OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1),
+                OmniBookmark("b2", "b1", 0, "B", "https://b.example", 1, 1)
+            ),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.UNKNOWN_PARENT })
+    }
+
+    @Test
+    fun validate_timestampReversed_detectedAsWarning() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 100, 50)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.TIMESTAMP_REVERSED })
+    }
+
+    @Test
+    fun validate_timestampOutOfRange_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", -1, 50)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.TIMESTAMP_OUT_OF_RANGE })
+    }
+
+    @Test
+    fun validate_timestampFarFuture_detected() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 5_000_000_000_000L, 5_000_000_000_000L)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.TIMESTAMP_OUT_OF_RANGE })
+    }
+
+    @Test
+    fun validate_wellFormedData_noIssues() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(
+                OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 100, 200),
+                OmniBookmark("b2", "f1", 0, "B", "https://b.example", 100, 200)
+            ),
+            newFolders = listOf(
+                OmniBookmarkFolder("f1", ROOT_FOLDER_ID, 1, "F", 100, 200)
+            )
+        )
+        assertTrue("Expected no issues but got: $issues", issues.isEmpty())
+    }
+
+    @Test
+    fun validate_zeroTimestamps_areAcceptable() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 0, 0)),
+            newFolders = emptyList()
+        )
+        assertFalse(issues.any { it.kind == BookmarkValidationIssue.Kind.TIMESTAMP_OUT_OF_RANGE })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // 2. ORDERING TESTS — Exhaustive move coverage
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun ordering_moveFirstToLast_withinSameParent() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addBookmark("D", "https://d.example")
+        assertTrue(c.moveItem(a.id, ROOT_FOLDER_ID, 2))
+        assertEquals(listOf(b.id, d.id, a.id), c.childIds(ROOT_FOLDER_ID))
+        assertEquals(listOf(0L, 1L, 2L), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.position })
+    }
+
+    @Test
+    fun ordering_moveLastToFirst_withinSameParent() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addBookmark("D", "https://d.example")
+        assertTrue(c.moveItem(d.id, ROOT_FOLDER_ID, 0))
+        assertEquals(listOf(d.id, a.id, b.id), c.childIds(ROOT_FOLDER_ID))
+    }
+
+    @Test
+    fun ordering_moveMiddleToAnotherMiddle_withinSameParent() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addBookmark("D", "https://d.example")
+        val e = c.addBookmark("E", "https://e.example")
+        // Move B (index 1) to index 2 → A, D, B, E
+        assertTrue(c.moveItem(b.id, ROOT_FOLDER_ID, 2))
+        assertEquals(listOf(a.id, d.id, b.id, e.id), c.childIds(ROOT_FOLDER_ID))
+    }
+
+    @Test
+    fun ordering_moveFolder_withinSameParent() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val f = c.addFolder("F")
+        val b = c.addBookmark("B", "https://b.example")
+        assertTrue(c.moveItem(f.id, ROOT_FOLDER_ID, 2)) // move to end
+        assertEquals(listOf(a.id, b.id, f.id), c.childIds(ROOT_FOLDER_ID))
+    }
+
+    @Test
+    fun ordering_moveBookmarkToEmptyFolder() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val f = c.addFolder("F")
+        assertTrue(c.moveItem(a.id, f.id, 0))
+        assertEquals(listOf(f.id), c.childIds(ROOT_FOLDER_ID)) // root still has the folder
+        assertEquals(listOf(a.id), c.childIds(f.id))
+        assertEquals(0L, c.bookmark(a.id)!!.position)
+    }
+
+    @Test
+    fun ordering_moveFolderToEmptyFolder() {
+        val c = newCollection()
+        val f1 = c.addFolder("F1")
+        val f2 = c.addFolder("F2")
+        assertTrue(c.moveItem(f1.id, f2.id, 0))
+        assertEquals(listOf(f1.id), c.childIds(f2.id))
+        assertEquals(0L, c.folder(f1.id)!!.position)
+    }
+
+    @Test
+    fun ordering_moveFromEmptySource_parentStaysValid() {
+        val c = newCollection()
+        val f = c.addFolder("F")
+        val a = c.addBookmark("A", "https://a.example")
+        assertTrue(c.moveItem(a.id, f.id, 0))
+        assertEquals(1, c.childCount(ROOT_FOLDER_ID)) // root still has the folder F
+    }
+
+    @Test
+    fun ordering_crossParentMixedTypes_interleavesCorrectly() {
+        val c = newCollection()
+        val src = c.addFolder("Src")
+        val dst = c.addFolder("Dst")
+        val bm1 = c.addBookmark("BM1", "https://1.example", parentId = src.id)
+        val fSub = c.addFolder("Sub", parentId = src.id)
+        val bm2 = c.addBookmark("BM2", "https://2.example", parentId = src.id)
+        // Move folder Sub to Dst at position 0.
+        assertTrue(c.moveItem(fSub.id, dst.id, 0))
+        assertEquals(listOf(bm1.id, bm2.id), c.childIds(src.id))
+        assertEquals(listOf(fSub.id), c.childIds(dst.id))
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // 3. PROPERTY / INVARIANT TESTS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /** Helper: assert every parent in [c] has dense 0-based positions. */
+    private fun assertDensePositions(c: BookmarkCollection) {
+        val allParents = (c.allBookmarks().map { it.parentId } + c.allFolders().map { it.parentId } + ROOT_FOLDER_ID).toSet()
+        allParents.forEach { parentId ->
+            val ids = c.childIds(parentId)
+            val positions = ids.map { c.bookmark(it)?.position ?: c.folder(it)?.position ?: -1L }
+            val expected = (0L until positions.size.toLong()).toList()
+            assertEquals("Positions for parent $parentId must be dense 0-based", expected, positions)
+        }
+    }
+
+    /** Helper: assert no duplicate IDs anywhere. */
+    private fun assertNoDuplicateIds(c: BookmarkCollection) {
+        val allIds = c.allBookmarks().map { it.id } + c.allFolders().map { it.id }
+        assertEquals("All ids must be unique", allIds.size, allIds.toSet().size)
+    }
+
+    /** Helper: assert every non-root parent exists as a folder. */
+    private fun assertParentsExist(c: BookmarkCollection) {
+        val folderIds = c.allFolders().map { it.id }.toSet()
+        c.allBookmarks().forEach { assertTrue("Bookmark ${it.id} parent ${it.parentId} must exist", it.parentId == ROOT_FOLDER_ID || it.parentId in folderIds) }
+        c.allFolders().forEach { assertTrue("Folder ${it.id} parent ${it.parentId} must exist", it.parentId == ROOT_FOLDER_ID || it.parentId in folderIds) }
+    }
+
+    /** Helper: assert no cycles in the folder graph. */
+    private fun assertNoCycles(c: BookmarkCollection) {
+        val parentOf = c.allFolders().associate { it.id to it.parentId }
+        c.allFolders().forEach { f ->
+            val visited = mutableSetOf<String>()
+            var current = f.parentId
+            while (current != ROOT_FOLDER_ID && current in parentOf) {
+                assertFalse("Cycle detected involving ${f.id}", current in visited)
+                visited.add(current)
+                current = parentOf[current] ?: break
+                if (current == f.id) {
+                    fail("Folder ${f.id} is its own ancestor")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun invariant_afterAddBookmark_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        c.addBookmark("A", "https://a.example")
+        c.addBookmark("B", "https://b.example")
+        val f = c.addFolder("F")
+        c.addBookmark("C", "https://c.example", parentId = f.id)
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterAddFolder_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val l1 = c.addFolder("L1")
+        val l2 = c.addFolder("L2", parentId = l1.id)
+        val l3 = c.addFolder("L3", parentId = l2.id)
+        c.addBookmark("deep", "https://deep.example", parentId = l3.id)
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterMoveItem_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addBookmark("D", "https://d.example")
+        val f = c.addFolder("F")
+        c.moveItem(a.id, f.id, 0)
+        c.moveItem(d.id, ROOT_FOLDER_ID, 0)
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterMoveFolder_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val outer = c.addFolder("Outer")
+        val inner = c.addFolder("Inner", parentId = outer.id)
+        c.addBookmark("x", "https://x.example", parentId = inner.id)
+        val dst = c.addFolder("Dst")
+        c.moveItem(outer.id, dst.id, 0)
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterDeleteBookmark_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addBookmark("D", "https://d.example")
+        c.deleteItem(a.id)
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterDeleteFolder_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val outer = c.addFolder("Outer")
+        val inner = c.addFolder("Inner", parentId = outer.id)
+        c.addBookmark("x", "https://x.example", parentId = inner.id)
+        c.addBookmark("y", "https://y.example", parentId = outer.id)
+        c.deleteItem(outer.id)
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterRename_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        c.rename(a.id, "Renamed")
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterSetUrl_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        c.setUrl(a.id, "https://new.example")
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_afterComplexSequence_denseNoDuplicatesParentsExistNoCycles() {
+        val c = newCollection()
+        val work = c.addFolder("Work")
+        val personal = c.addFolder("Personal")
+        val docs = c.addFolder("Docs", parentId = work.id)
+        c.addBookmark("Sheet", "https://sheet.example", parentId = work.id)
+        val resume = c.addBookmark("Resume", "https://resume.example", parentId = docs.id)
+
+        c.moveItem(docs.id, personal.id, 0)
+        c.rename(resume.id, "CV")
+        c.deleteItem(personal.id)
+
+        assertDensePositions(c)
+        assertNoDuplicateIds(c)
+        assertParentsExist(c)
+        assertNoCycles(c)
+    }
+
+    @Test
+    fun invariant_positionsMatchChildCounts() {
+        val c = newCollection()
+        val f1 = c.addFolder("F1")
+        val a = c.addBookmark("A", "https://a.example")
+        c.addBookmark("B", "https://b.example", parentId = f1.id)
+        c.addFolder("F2", parentId = f1.id)
+
+        assertEquals(2, c.childCount(ROOT_FOLDER_ID)) // F1 + A
+        assertEquals(listOf(0L, 1L), c.childIds(ROOT_FOLDER_ID).indices.map { it.toLong() })
+        assertEquals(2, c.childCount(f1.id)) // B + F2
+        assertEquals(listOf(0L, 1L), c.childIds(f1.id).indices.map { it.toLong() })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // 4. ROOT SEMANTICS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun rootFolderId_isImplicit_neverPersisted() {
+        val c = newCollection()
+        c.addBookmark("A", "https://a.example")
+        c.addFolder("F")
+        assertNull(c.folder(ROOT_FOLDER_ID))
+        assertEquals(1, c.folderCount()) // one real folder 'F'
+        assertEquals(1, c.bookmarkCount())
+    }
+
+    @Test
+    fun rootFolderId_isTopLevelParent() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        assertEquals(ROOT_FOLDER_ID, c.bookmark(a.id)!!.parentId)
+        assertEquals(listOf(a.id), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.id })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // 5. ADDITIONAL EDGE CASES
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun moveItem_toSamePosition_withinSameParent_noOp() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val original = c.childIds(ROOT_FOLDER_ID)
+        assertTrue(c.moveItem(a.id, ROOT_FOLDER_ID, 0))
+        assertEquals(original, c.childIds(ROOT_FOLDER_ID))
+    }
+
+    @Test
+    fun moveItem_clampsNegativeIndexToZero() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        assertTrue(c.moveItem(b.id, ROOT_FOLDER_ID, -5))
+        assertEquals(listOf(b.id, a.id), c.childIds(ROOT_FOLDER_ID))
+    }
+
+    @Test
+    fun deleteOnlyItem_leavesParentEmpty() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        c.deleteItem(a.id)
+        assertEquals(0, c.childCount(ROOT_FOLDER_ID))
+        assertTrue(c.childIds(ROOT_FOLDER_ID).isEmpty())
+    }
+
+    @Test
+    fun buildTree_emptyCollection_returnsRootWithNoChildren() {
+        val c = newCollection()
+        val root = c.buildTree()
+        assertEquals(ROOT_FOLDER_ID, root.id)
+        assertTrue(root.children.isEmpty())
+    }
+
+    @Test
+    fun descendantsOf_leafFolder_returnsEmpty() {
+        val c = newCollection()
+        val f = c.addFolder("F")
+        assertEquals(emptySet<String>(), c.descendantsOf(f.id))
+    }
+
+    @Test
+    fun descendantsOf_unknownId_returnsEmpty() {
+        val c = newCollection()
+        assertEquals(emptySet<String>(), c.descendantsOf("ghost"))
+    }
+}

--- a/app/src/test/java/com/rebelroot/omni/bookmarks/model/BookmarkCollectionTest.kt
+++ b/app/src/test/java/com/rebelroot/omni/bookmarks/model/BookmarkCollectionTest.kt
@@ -1,0 +1,409 @@
+/*
+ * Omni Browser - Canonical Bookmark Model Unit Tests
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Phase 01 gate: stable identity, folder hierarchy, deterministic ordering,
+ * moves, deletes, duplicate bookmarks, empty folders and integrity checks.
+ */
+
+package com.rebelroot.omni.bookmarks.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BookmarkCollectionTest {
+
+    /** Deterministic clock so timestamps are stable across test runs. */
+    private fun newCollection() = BookmarkCollection { 1_000_000L }
+
+    // ── Identity ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun addBookmark_assignsStableUniqueIds() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        assertNotEquals(a.id, b.id)
+        assertNotNull(a.id)
+        assertFalse(a.id.isBlank())
+    }
+
+    @Test
+    fun addBookmark_sameUrlTwice_createsDistinctItems() {
+        val c = newCollection()
+        val a = c.addBookmark("Same", "https://dup.example")
+        val b = c.addBookmark("Same", "https://dup.example")
+        assertNotEquals(a.id, b.id)
+        assertEquals(2, c.bookmarkCount())
+        // URL identity must not collide with canonical ids.
+        assertNull(c.bookmark(a.id + "x"))
+    }
+
+    @Test
+    fun addBookmark_sameTitleDifferentUrl_allowed() {
+        val c = newCollection()
+        c.addBookmark("Title", "https://one.example")
+        c.addBookmark("Title", "https://two.example")
+        assertEquals(2, c.bookmarkCount())
+    }
+
+    @Test
+    fun addToUnknownParent_throws() {
+        val c = newCollection()
+        try {
+            c.addBookmark("x", "https://x.example", parentId = "nope")
+            throw AssertionError("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+        try {
+            c.addFolder("x", parentId = "nope")
+            throw AssertionError("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    // ── Hierarchy ────────────────────────────────────────────────────────────
+
+    @Test
+    fun addFolder_childrenAppearUnderParent() {
+        val c = newCollection()
+        val folder = c.addFolder("Work")
+        val bm = c.addBookmark("Docs", "https://docs.example", parentId = folder.id)
+        assertEquals(listOf(folder.id), c.folderChildren(ROOT_FOLDER_ID).map { it.id })
+        assertEquals(listOf(bm.id), c.bookmarkChildren(folder.id).map { it.id })
+        assertEquals(0, c.bookmarkChildren(ROOT_FOLDER_ID).size)
+    }
+
+    @Test
+    fun nestedFolders_arbitraryDepth_allowed() {
+        val c = newCollection()
+        val l1 = c.addFolder("L1")
+        val l2 = c.addFolder("L2", parentId = l1.id)
+        val l3 = c.addFolder("L3", parentId = l2.id)
+        val bm = c.addBookmark("deep", "https://deep.example", parentId = l3.id)
+        assertEquals(l1.id, c.folder(l2.id)!!.parentId)
+        assertEquals(l2.id, c.folder(l3.id)!!.parentId)
+        assertEquals(l3.id, c.bookmark(bm.id)!!.parentId)
+    }
+
+    @Test
+    fun emptyFolder_isAllowed() {
+        val c = newCollection()
+        val folder = c.addFolder("Empty")
+        assertTrue(c.bookmarkChildren(folder.id).isEmpty())
+        assertTrue(c.folderChildren(folder.id).isEmpty())
+        assertEquals(1, c.folderCount())
+    }
+
+    // ── Ordering ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun appendPositions_areSequential() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addFolder("D")
+        val e = c.addBookmark("E", "https://e.example")
+        assertEquals(0L, a.position)
+        assertEquals(1L, b.position)
+        assertEquals(2L, d.position)
+        assertEquals(3L, e.position)
+        // Folders and bookmarks share the same position space inside a parent.
+        assertEquals(listOf(a.id, b.id, d.id, e.id), c.childIds(ROOT_FOLDER_ID))
+    }
+
+    @Test
+    fun childrenAreSortedByPosition() {
+        val c = newCollection()
+        val z = c.addBookmark("Z", "https://z.example", position = 3)
+        val a = c.addBookmark("A", "https://a.example", position = 0)
+        val m = c.addBookmark("M", "https://m.example", position = 1)
+        assertEquals(listOf(a.id, m.id, z.id), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.id })
+    }
+
+    @Test
+    fun moveItem_withinSameParent_shiftsDensely() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        val d = c.addBookmark("D", "https://d.example")
+        // Move A to index 2 → B, D, A
+        assertTrue(c.moveItem(a.id, ROOT_FOLDER_ID, 2))
+        assertEquals(listOf(b.id, d.id, a.id), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.id })
+        assertEquals(listOf(0L, 1L, 2L), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.position })
+    }
+
+    @Test
+    fun moveItem_toBack_clampsToEnd() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        assertTrue(c.moveItem(a.id, ROOT_FOLDER_ID, 99))
+        assertEquals(listOf(b.id, a.id), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.id })
+    }
+
+    @Test
+    fun moveItem_acrossParents_reindexesBoth() {
+        val c = newCollection()
+        val folder = c.addFolder("Folder")
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        assertTrue(c.moveItem(a.id, folder.id, 0))
+        assertEquals(listOf(b.id), c.bookmarkChildren(ROOT_FOLDER_ID).map { it.id })
+        assertEquals(1L, c.bookmark(b.id)!!.position) // folder occupies position 0
+        assertEquals(listOf(a.id), c.bookmarkChildren(folder.id).map { it.id })
+        assertEquals(folder.id, c.bookmark(a.id)!!.parentId)
+    }
+
+    @Test
+    fun moveUnknownItem_returnsFalse() {
+        val c = newCollection()
+        assertFalse(c.moveItem("ghost", ROOT_FOLDER_ID, 0))
+    }
+
+    @Test
+    fun moveFolder_intoItself_throws() {
+        val c = newCollection()
+        val f = c.addFolder("F")
+        try {
+            c.moveItem(f.id, f.id, 0)
+            throw AssertionError("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun moveFolder_intoOwnDescendant_throws() {
+        val c = newCollection()
+        val l1 = c.addFolder("L1")
+        val l2 = c.addFolder("L2", parentId = l1.id)
+        try {
+            c.moveItem(l1.id, l2.id, 0)
+            throw AssertionError("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    // ── Deletion ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun deleteBookmark_removesOnlyThatItem() {
+        val c = newCollection()
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example")
+        assertTrue(c.deleteItem(a.id))
+        assertNull(c.bookmark(a.id))
+        assertNotNull(c.bookmark(b.id))
+        assertEquals(1, c.bookmarkCount())
+        assertEquals(0L, c.bookmark(b.id)!!.position) // stays dense
+    }
+
+    @Test
+    fun deleteFolder_cascadesToDirectAndNestedChildren() {
+        val c = newCollection()
+        val outer = c.addFolder("Outer")
+        val inner = c.addFolder("Inner", parentId = outer.id)
+        val direct = c.addBookmark("direct", "https://direct.example", parentId = outer.id)
+        val nested = c.addBookmark("nested", "https://nested.example", parentId = inner.id)
+        val sibling = c.addBookmark("sibling", "https://sibling.example")
+        assertTrue(c.deleteItem(outer.id))
+        assertNull(c.folder(outer.id))
+        assertNull(c.folder(inner.id))
+        assertNull(c.bookmark(direct.id))
+        assertNull(c.bookmark(nested.id))
+        assertNotNull(c.bookmark(sibling.id))
+        assertEquals(1, c.bookmarkCount())
+        assertEquals(0, c.folderCount())
+    }
+
+    @Test
+    fun deleteUnknownId_returnsFalse() {
+        val c = newCollection()
+        assertFalse(c.deleteItem("ghost"))
+    }
+
+    // ── Rename / URL update ──────────────────────────────────────────────────
+
+    @Test
+    fun rename_updatesTitleAndModifiedAt() {
+        var t = 1_000L
+        val c = BookmarkCollection { t++ }
+        val bm = c.addBookmark("Old", "https://a.example")
+        val before = c.bookmark(bm.id)!!.modifiedAt
+        assertTrue(c.rename(bm.id, "New"))
+        assertEquals("New", c.bookmark(bm.id)!!.title)
+        assertTrue(c.bookmark(bm.id)!!.modifiedAt > before)
+    }
+
+    @Test
+    fun renameUnknownId_returnsFalse() {
+        val c = newCollection()
+        assertFalse(c.rename("ghost", "x"))
+    }
+
+    @Test
+    fun setUrl_updatesOnlyUrl() {
+        val c = newCollection()
+        val bm = c.addBookmark("A", "https://old.example")
+        assertTrue(c.setUrl(bm.id, "https://new.example"))
+        assertEquals("https://new.example", c.bookmark(bm.id)!!.url)
+        assertEquals("A", c.bookmark(bm.id)!!.title)
+    }
+
+    @Test
+    fun setUrl_onFolder_returnsFalse() {
+        val c = newCollection()
+        val f = c.addFolder("F")
+        assertFalse(c.setUrl(f.id, "https://x.example"))
+    }
+
+    // ── Tree ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun buildTree_preservesHierarchyAndOrder() {
+        val c = newCollection()
+        val folder = c.addFolder("F")
+        val a = c.addBookmark("A", "https://a.example")
+        val b = c.addBookmark("B", "https://b.example", parentId = folder.id)
+        val sub = c.addFolder("Sub", parentId = folder.id)
+        val deep = c.addBookmark("Deep", "https://deep.example", parentId = sub.id)
+
+        val root = c.buildTree()
+        assertEquals(ROOT_FOLDER_ID, root.id)
+        assertEquals(2, root.children.size)
+        val rootChild = root.children.first { it.id == a.id } as BookmarkNode.Item
+        assertEquals(a.id, rootChild.id)
+
+        val folderNode = root.children.first { it.id == folder.id } as BookmarkNode.Folder
+        assertEquals(listOf(b.id, sub.id), folderNode.children.map { it.id })
+        val subNode = folderNode.children.last() as BookmarkNode.Folder
+        assertEquals(listOf(deep.id), subNode.children.map { it.id })
+    }
+
+    @Test
+    fun buildTree_sortsChildrenByPositionAcrossTypes() {
+        val c = newCollection()
+        val bm0 = c.addBookmark("bm0", "https://0.example", position = 1)
+        val f = c.addFolder("folder", position = 0)
+        val bm2 = c.addBookmark("bm2", "https://2.example", position = 2)
+        val root = c.buildTree()
+        assertEquals(listOf(f.id, bm0.id, bm2.id), root.children.map { it.id })
+    }
+
+    @Test
+    fun descendantsOf_deepNested_findsAll() {
+        val c = newCollection()
+        val l1 = c.addFolder("L1")
+        val l2 = c.addFolder("L2", parentId = l1.id)
+        val l3 = c.addFolder("L3", parentId = l2.id)
+        val other = c.addFolder("Other")
+        assertEquals(setOf(l2.id, l3.id), c.descendantsOf(l1.id))
+        assertEquals(emptySet<String>(), c.descendantsOf(other.id))
+    }
+
+    // ── Integrity ────────────────────────────────────────────────────────────
+
+    @Test
+    fun validate_wellFormedCollection_noIssues() {
+        val c = newCollection()
+        val f = c.addFolder("F")
+        c.addBookmark("A", "https://a.example")
+        c.addBookmark("B", "https://b.example", parentId = f.id)
+        assertTrue(c.validate().isEmpty())
+    }
+
+    @Test
+    fun validate_reportsUnknownParent() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", "missing", 0, "A", "https://a.example", 1, 1)),
+            newFolders = emptyList()
+        )
+        assertEquals(1, issues.count { it.kind == BookmarkValidationIssue.Kind.UNKNOWN_PARENT })
+    }
+
+    @Test
+    fun validate_reportsNegativePosition() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, -1, "A", "https://a.example", 1, 1)),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.NEGATIVE_POSITION })
+    }
+
+    @Test
+    fun validate_reportsDuplicatePosition() {
+        val issues = BookmarkCollection.validate(
+            newBookmarks = listOf(
+                OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1),
+                OmniBookmark("b2", ROOT_FOLDER_ID, 0, "B", "https://b.example", 1, 1)
+            ),
+            newFolders = emptyList()
+        )
+        assertTrue(issues.any { it.kind == BookmarkValidationIssue.Kind.DUPLICATE_POSITION })
+    }
+
+    @Test
+    fun unvalidatedCandidate_mustBeCheckedBeforeCommit() {
+        val c = newCollection()
+        val keep = c.addBookmark("keep", "https://keep.example")
+        val candidate = listOf(OmniBookmark("b1", "missing-parent", 0, "A", "https://a.example", 1, 1))
+        val issues = BookmarkCollection.validate(candidate, emptyList())
+        assertTrue(issues.isNotEmpty())
+        // Storage-layer pattern: commit only when validation is clean.
+        if (issues.isEmpty()) c.replaceAll(candidate, emptyList())
+        // Original state must be untouched.
+        assertNotNull(c.bookmark(keep.id))
+        assertEquals(1, c.bookmarkCount())
+    }
+
+    @Test
+    fun replaceAll_validData_swapsState() {
+        val c = newCollection()
+        c.addBookmark("old", "https://old.example")
+        c.replaceAll(
+            newBookmarks = listOf(OmniBookmark("b1", ROOT_FOLDER_ID, 0, "A", "https://a.example", 1, 1)),
+            newFolders = listOf(OmniBookmarkFolder("f1", ROOT_FOLDER_ID, 1, "F", 1, 1))
+        )
+        assertEquals(1, c.bookmarkCount())
+        assertEquals(1, c.folderCount())
+        assertEquals(listOf("b1", "f1"), c.childIds(ROOT_FOLDER_ID))
+    }
+
+    // ── Multi-edit sequence ──────────────────────────────────────────────────
+
+    @Test
+    fun complexSequence_remainsConsistent() {
+        val c = newCollection()
+        val work = c.addFolder("Work")
+        val personal = c.addFolder("Personal")
+        val docs = c.addFolder("Docs", parentId = work.id)
+        c.addBookmark("Sheet", "https://sheet.example", parentId = work.id)
+        val resume = c.addBookmark("Resume", "https://resume.example", parentId = docs.id)
+
+        // Move the Docs folder (with Resume inside) from Work to Personal.
+        assertTrue(c.moveItem(docs.id, personal.id, 0))
+        assertEquals(personal.id, c.folder(docs.id)!!.parentId)
+        assertEquals(docs.id, c.bookmark(resume.id)!!.parentId)
+        assertTrue(c.validate().isEmpty())
+
+        // Rename the Resume bookmark.
+        assertTrue(c.rename(resume.id, "CV"))
+        assertEquals("CV", c.bookmark(resume.id)!!.title)
+
+        // Delete Personal → Docs → Resume cascade.
+        assertTrue(c.deleteItem(personal.id))
+        assertNull(c.folder(docs.id))
+        assertNull(c.bookmark(resume.id))
+        assertTrue(c.validate().isEmpty())
+        assertEquals(listOf(work.id), c.folderChildren(ROOT_FOLDER_ID).map { it.id })
+    }
+}

--- a/app/src/test/java/com/rebelroot/omni/bookmarks/parser/NetscapeBookmarkParserTest.kt
+++ b/app/src/test/java/com/rebelroot/omni/bookmarks/parser/NetscapeBookmarkParserTest.kt
@@ -1,0 +1,375 @@
+/*
+ * Omni Browser - Netscape Bookmark HTML Parser Tests
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Phase 03 gate: parser correctness, security limits, malformed input handling.
+ */
+
+package com.rebelroot.omni.bookmarks.parser
+
+import com.rebelroot.omni.bookmarks.model.ROOT_FOLDER_ID
+import org.junit.Test
+import org.junit.Assert.*
+
+class NetscapeBookmarkParserTest {
+
+    private fun parse(html: String) = parseNetscapeBookmarkHtml(html) { 1_000_000L }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Basic parsing
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun parse_emptyInput_producesEmptyCollection() {
+        val result = parse("")
+        assertEquals(0, result.importedBookmarks)
+        assertEquals(0, result.importedFolders)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun parse_singleBookmark() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><A HREF="https://google.com" ADD_DATE="1234567890">Google</A>
+</DL><p>
+"""
+        val result = parse(html)
+        assertEquals(1, result.importedBookmarks)
+        assertEquals(0, result.importedFolders)
+        val bm = result.collection.allBookmarks().first()
+        assertEquals("Google", bm.title)
+        assertEquals("https://google.com", bm.url)
+        assertEquals(ROOT_FOLDER_ID, bm.parentId)
+    }
+
+    @Test
+    fun parse_multipleBookmarks() {
+        val html = """<DL><p>
+    <DT><A HREF="https://a.example">A</A>
+    <DT><A HREF="https://b.example">B</A>
+    <DT><A HREF="https://c.example">C</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(3, result.importedBookmarks)
+        assertEquals(listOf("A", "B", "C"), result.collection.allBookmarks().map { it.title })
+    }
+
+    @Test
+    fun parse_folderWithBookmarks() {
+        val html = """<DL><p>
+    <DT><H3>Work</H3>
+    <DL><p>
+        <DT><A HREF="https://docs.example">Docs</A>
+        <DT><A HREF="https://sheet.example">Sheet</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(1, result.importedFolders)
+        assertEquals(2, result.importedBookmarks)
+        val folder = result.collection.allFolders().first()
+        assertEquals("Work", folder.title)
+        assertEquals(ROOT_FOLDER_ID, folder.parentId)
+        assertEquals(2, result.collection.bookmarkChildren(folder.id).size)
+    }
+
+    @Test
+    fun parse_nestedFolders() {
+        val html = """<DL><p>
+    <DT><H3>Outer</H3>
+    <DL><p>
+        <DT><H3>Inner</H3>
+        <DL><p>
+            <DT><A HREF="https://deep.example">Deep</A>
+        </DL><p>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedFolders)
+        assertEquals(1, result.importedBookmarks)
+        val outer = result.collection.allFolders().first { it.title == "Outer" }
+        val inner = result.collection.allFolders().first { it.title == "Inner" }
+        assertEquals(outer.id, inner.parentId)
+        val bm = result.collection.allBookmarks().first()
+        assertEquals(inner.id, bm.parentId)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // HTML entities
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun parse_htmlEntitiesInTitle() {
+        val html = """<DL><p>
+    <DT><A HREF="https://example.com">AT&amp;T &lt;test&gt;</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals("AT&T <test>", result.collection.allBookmarks().first().title)
+    }
+
+    @Test
+    fun parse_htmlEntitiesInUrl() {
+        val html = """<DL><p>
+    <DT><A HREF="https://example.com?q=a&amp;b=c">Test</A>
+</DL><p>"""
+        val result = parse(html)
+        // URLs should NOT have HTML entities decoded — the browser exports them encoded.
+        assertEquals("https://example.com?q=a&amp;b=c", result.collection.allBookmarks().first().url)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Security / malformed input
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun parse_javascriptScheme_skippedWithWarning() {
+        val html = """<DL><p>
+    <DT><A HREF="javascript:alert('xss')">Bad</A>
+    <DT><A HREF="https://good.example">Good</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(1, result.importedBookmarks)
+        assertEquals(1, result.skippedEntries)
+        assertTrue(result.warnings.any { it.message.contains("Skipped") })
+    }
+
+    @Test
+    fun parse_dataScheme_skipped() {
+        val html = """<DL><p>
+    <DT><A HREF="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;">Bad</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(0, result.importedBookmarks)
+        assertEquals(1, result.skippedEntries)
+    }
+
+    @Test(expected = ParseException::class)
+    fun parse_excessiveDepth_throws() {
+        val html = buildString {
+            append("<DL><p>\n")
+            repeat(101) { append("<DT><H3>F</H3>\n<DL><p>\n") }
+        }
+        parse(html)
+    }
+
+    @Test(expected = ParseException::class)
+    fun parse_excessiveFileSize_throws() {
+        val huge = "A".repeat(11 * 1024 * 1024)
+        parse(huge)
+    }
+
+    @Test
+    fun parse_emptyHref_skipped() {
+        val html = """<DL><p>
+    <DT><A HREF="">Empty</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(0, result.importedBookmarks)
+        assertEquals(1, result.skippedEntries)
+    }
+
+    @Test
+    fun parse_missingHref_notTreatedAsBookmark() {
+        val html = """<DL><p>
+    <DT><A>Missing href</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(0, result.importedBookmarks)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Edge cases
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun parse_emptyFolder() {
+        val html = """<DL><p>
+    <DT><H3>Empty</H3>
+    <DL><p>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(1, result.importedFolders)
+        assertEquals(0, result.importedBookmarks)
+    }
+
+    @Test
+    fun parse_duplicateUrls_allowed() {
+        val html = """<DL><p>
+    <DT><A HREF="https://dup.example">First</A>
+    <DT><A HREF="https://dup.example">Second</A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedBookmarks)
+    }
+
+    @Test
+    fun parse_positionsAreDense() {
+        val html = """<DL><p>
+    <DT><A HREF="https://a.example">A</A>
+    <DT><A HREF="https://b.example">B</A>
+    <DT><A HREF="https://c.example">C</A>
+</DL><p>"""
+        val result = parse(html)
+        val positions = result.collection.allBookmarks().map { it.position }.sorted()
+        assertEquals(listOf(0L, 1L, 2L), positions)
+    }
+
+    @Test
+    fun parse_mixedFoldersAndBookmarks_orderPreserved() {
+        val html = """<DL><p>
+    <DT><A HREF="https://a.example">A</A>
+    <DT><H3>F1</H3>
+    <DL><p>
+        <DT><A HREF="https://b.example">B</A>
+    </DL><p>
+    <DT><A HREF="https://c.example">C</A>
+</DL><p>"""
+        val result = parse(html)
+        val rootIds = result.collection.childIds(ROOT_FOLDER_ID)
+        assertEquals(3, rootIds.size) // A, F1, C
+        assertEquals("A", result.collection.bookmark(rootIds[0])?.title)
+        assertEquals("F1", result.collection.folder(rootIds[1])?.title)
+        assertEquals("C", result.collection.bookmark(rootIds[2])?.title)
+    }
+
+    @Test
+    fun parse_bookmarkWithoutTitle_usesUrlAsTitle() {
+        val html = """<DL><p>
+    <DT><A HREF="https://example.com"></A>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals("https://example.com", result.collection.allBookmarks().first().title)
+    }
+
+    @Test
+    fun parse_noBookmarksOrFolders_returnsEmpty() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(0, result.totalEntries)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Real-world format variations
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun parse_chromeStyleExport() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+     It will be read and overwritten.
+     DO NOT EDIT! -->
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><A HREF="https://www.google.com/" ADD_DATE="1609459200" ICON="data:image/png;base64,iVBOR...">Google</A>
+    <DT><H3 ADD_DATE="1609459200" LAST_MODIFIED="1609459200">Bookmarks Bar</H3>
+    <DL><p>
+        <DT><A HREF="https://github.com/" ADD_DATE="1609459200">GitHub</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedBookmarks)
+        assertEquals(1, result.importedFolders)
+        assertTrue(result.collection.allBookmarks().any { it.title == "Google" })
+        assertTrue(result.collection.allBookmarks().any { it.title == "GitHub" })
+    }
+
+    @Test
+    fun parse_firefoxStyleExport() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks Menu</H1>
+<DL><p>
+    <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
+    <DL><p>
+        <DT><A HREF="https://mozilla.org" ADD_DATE="1234567890" LAST_MODIFIED="1234567890">Mozilla</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(1, result.importedBookmarks)
+        assertEquals(1, result.importedFolders)
+    }
+
+    @Test
+    fun parse_safariStyleExport() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><H3>Favorites</H3>
+    <DL><p>
+        <DT><A HREF="https://apple.com">Apple</A>
+        <DT><A HREF="https://icloud.com">iCloud</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedBookmarks)
+        assertEquals(1, result.importedFolders)
+    }
+
+    @Test
+    fun parse_braveStyleExport() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><A HREF="https://brave.com" ADD_DATE="1609459200">Brave</A>
+    <DT><H3 ADD_DATE="1609459200">Other Bookmarks</H3>
+    <DL><p>
+        <DT><A HREF="https://duckduckgo.com" ADD_DATE="1609459200">DuckDuckGo</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedBookmarks)
+        assertEquals(1, result.importedFolders)
+    }
+
+    @Test
+    fun parse_edgeStyleExport() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><H3>Favorites bar</H3>
+    <DL><p>
+        <DT><A HREF="https://bing.com">Bing</A>
+    </DL><p>
+    <DT><H3>Other favorites</H3>
+    <DL><p>
+        <DT><A HREF="https://microsoft.com">Microsoft</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedBookmarks)
+        assertEquals(2, result.importedFolders)
+    }
+
+    @Test
+    fun parse_operaStyleExport() {
+        val html = """<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><A HREF="https://opera.com">Opera</A>
+    <DT><H3>Speed Dial</H3>
+    <DL><p>
+        <DT><A HREF="https://news.opera.com">News</A>
+    </DL><p>
+</DL><p>"""
+        val result = parse(html)
+        assertEquals(2, result.importedBookmarks)
+        assertEquals(1, result.importedFolders)
+    }
+}

--- a/app/src/test/java/com/rebelroot/omni/bookmarks/storage/BookmarkStorageTest.kt
+++ b/app/src/test/java/com/rebelroot/omni/bookmarks/storage/BookmarkStorageTest.kt
@@ -1,0 +1,226 @@
+/*
+ * Omni Browser - Bookmark Storage Unit Tests
+ * Copyright (C) 2026 RebelRoot Ltd
+ *
+ * Phase 02 gate: atomic writes, versioned format, legacy migration,
+ * corruption recovery, round-trip fidelity.
+ */
+
+package com.rebelroot.omni.bookmarks.storage
+
+import com.rebelroot.omni.bookmarks.model.*
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.After
+import java.io.File
+
+class BookmarkStorageTest {
+
+    private lateinit var tempDir: File
+
+    @Before
+    fun setup() {
+        tempDir = createTempDir("omni_bookmark_test_")
+    }
+
+    @After
+    fun teardown() {
+        tempDir.deleteRecursively()
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Round-trip
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun roundTrip_emptyCollection_producesEmptyCollection() {
+        val original = BookmarkCollection()
+        saveBookmarksToDir(tempDir, original)
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(0, loaded.bookmarkCount())
+        assertEquals(0, loaded.folderCount())
+    }
+
+    @Test
+    fun roundTrip_bookmarksAndFolders_preserved() {
+        val original = BookmarkCollection()
+        original.addBookmark("Google", "https://google.com")
+        original.addFolder("Work")
+        val docs = original.addFolder("Docs", parentId = original.allFolders().first().id)
+        original.addBookmark("Sheet", "https://sheet.example", parentId = docs.id)
+
+        saveBookmarksToDir(tempDir, original)
+        val loaded = loadBookmarksFromDir(tempDir)
+
+        assertEquals(2, loaded.bookmarkCount())
+        assertEquals(2, loaded.folderCount())
+        assertEquals("Work", loaded.allFolders().first { it.title == "Work" }.title)
+        val sheet = loaded.allBookmarks().first { it.title == "Sheet" }
+        assertEquals(docs.id, sheet.parentId)
+    }
+
+    @Test
+    fun roundTrip_positionsPreserved() {
+        val original = BookmarkCollection()
+        original.addBookmark("A", "https://a.example")
+        original.addBookmark("B", "https://b.example")
+        original.addFolder("F")
+        original.addBookmark("C", "https://c.example")
+
+        saveBookmarksToDir(tempDir, original)
+        val loaded = loadBookmarksFromDir(tempDir)
+
+        val ids = loaded.childIds(ROOT_FOLDER_ID)
+        assertEquals(4, ids.size)
+        assertEquals(listOf(0L, 1L, 2L, 3L), ids.map { loaded.bookmark(it)?.position ?: loaded.folder(it)!!.position })
+    }
+
+    @Test
+    fun roundTrip_timestampsPreserved() {
+        val original = BookmarkCollection { 1_234_567_890L }
+        original.addBookmark("T", "https://t.example")
+
+        saveBookmarksToDir(tempDir, original)
+        val loaded = loadBookmarksFromDir(tempDir)
+
+        val bm = loaded.allBookmarks().first()
+        assertEquals(1_234_567_890L, bm.createdAt)
+        assertEquals(1_234_567_890L, bm.modifiedAt)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Legacy migration
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun legacyMigration_flatBookmarks_migratedToRootLevel() {
+        // Write legacy format.
+        val legacyJson = """[
+            {"title":"Google","url":"https://google.com","timestamp":1000},
+            {"title":"GitHub","url":"https://github.com","timestamp":2000}
+        ]""".trimIndent()
+        File(tempDir, "browser_bookmarks.json").writeText(legacyJson)
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(2, loaded.bookmarkCount())
+        assertEquals(0, loaded.folderCount())
+        assertTrue(loaded.allBookmarks().any { it.title == "Google" && it.url == "https://google.com" })
+        assertTrue(loaded.allBookmarks().any { it.title == "GitHub" && it.url == "https://github.com" })
+    }
+
+    @Test
+    fun legacyMigration_densePositionsAssigned() {
+        val legacyJson = """[
+            {"title":"A","url":"https://a.example","timestamp":1000},
+            {"title":"B","url":"https://b.example","timestamp":2000}
+        ]""".trimIndent()
+        File(tempDir, "browser_bookmarks.json").writeText(legacyJson)
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        val positions = loaded.allBookmarks().map { it.position }
+        assertEquals(listOf(0L, 1L), positions.sorted())
+    }
+
+    @Test
+    fun legacyMigration_v2FileCreatedAfterMigration() {
+        File(tempDir, "browser_bookmarks.json").writeText("""[{"title":"X","url":"https://x.example"}]""")
+
+        loadBookmarksFromDir(tempDir)
+        assertTrue(File(tempDir, "browser_bookmarks_v2.json").exists())
+    }
+
+    @Test
+    fun legacyMigration_v2TakesPrecedenceOverLegacy() {
+        // Legacy has 1 bookmark, v2 has 2.
+        File(tempDir, "browser_bookmarks.json").writeText("""[{"title":"Legacy","url":"https://legacy.example"}]""")
+        val original = BookmarkCollection()
+        original.addBookmark("V2", "https://v2.example")
+        original.addBookmark("V2-2", "https://v2-2.example")
+        saveBookmarksToDir(tempDir, original)
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(2, loaded.bookmarkCount())
+        assertTrue(loaded.allBookmarks().any { it.title == "V2" })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Corruption recovery
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun corruptV2File_returnsEmptyCollection() {
+        File(tempDir, "browser_bookmarks_v2.json").writeText("not json at all {[")
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(0, loaded.bookmarkCount())
+    }
+
+    @Test
+    fun corruptV2File_doesNotCrash() {
+        File(tempDir, "browser_bookmarks_v2.json").writeText("{\"schema_version\":2,\"bookmarks\":[{\"id\":\"x\"}]}")
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(0, loaded.bookmarkCount())
+    }
+
+    @Test
+    fun missingFile_returnsEmptyCollection() {
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(0, loaded.bookmarkCount())
+        assertEquals(0, loaded.folderCount())
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Atomic write safety
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun atomicWrite_tempFileRemovedAfterSuccess() {
+        val collection = BookmarkCollection()
+        collection.addBookmark("A", "https://a.example")
+
+        saveBookmarksToDir(tempDir, collection)
+        assertFalse(File(tempDir, "browser_bookmarks_v2.json.tmp").exists())
+    }
+
+    @Test
+    fun atomicWrite_existingDataPreservedOnOverwrite() {
+        val first = BookmarkCollection()
+        first.addBookmark("First", "https://first.example")
+        saveBookmarksToDir(tempDir, first)
+
+        val second = BookmarkCollection()
+        second.addBookmark("Second", "https://second.example")
+        second.addFolder("Folder")
+        saveBookmarksToDir(tempDir, second)
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(1, loaded.bookmarkCount())
+        assertEquals(1, loaded.folderCount())
+        assertTrue(loaded.allBookmarks().any { it.title == "Second" })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Schema version
+    // ═══════════════════════════════════════════════════════════════════════
+
+    @Test
+    fun schemaVersion_writtenToFile() {
+        val collection = BookmarkCollection()
+        collection.addBookmark("A", "https://a.example")
+
+        saveBookmarksToDir(tempDir, collection)
+        val text = File(tempDir, "browser_bookmarks_v2.json").readText()
+        assertTrue(text.contains("\"schema_version\":2"))
+    }
+
+    @Test
+    fun unknownSchemaVersion_treatedAsEmpty() {
+        File(tempDir, "browser_bookmarks_v2.json").writeText("""{"schema_version":99,"bookmarks":[],"folders":[]}""")
+
+        val loaded = loadBookmarksFromDir(tempDir)
+        assertEquals(0, loaded.bookmarkCount())
+    }
+}


### PR DESCRIPTION
Repository audit (Phase 00) found the current bookmark model is a flat 3-field list (title/url/timestamp) with no IDs, folders, ordering, or versioned storage — unable to represent bookmarks imported from mainstream browsers.

Add the sync-ready canonical model (Phase 01), pure Kotlin with no Android dependencies:
- OmniBookmark / OmniBookmarkFolder: stable UUID id, parentId, dense 0-based position, created/modified timestamps
- BookmarkCollection: add/move/delete/rename, cycle prevention, cascade delete with dense reindexing, derived tree (BookmarkNode)
- Companion validate() as a static pre-check on candidate datasets so untrusted import data can never partially corrupt live bookmarks
- 32 unit tests covering identity, hierarchy, ordering, moves, deletes, duplicates, empty folders and integrity checks (all passing)

## 📋 Description

<!-- What does this PR do? Why is it needed? -->

## 🔗 Related Issue

Closes #<!-- issue number -->

## 🧪 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (no functional change)
- [ ] 📖 Documentation update
- [ ] 🎨 UI / Style change
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build, CI, dependencies)

## 📸 Screenshots / Screen Recording

<!-- For UI changes, add before/after screenshots or a GIF -->

| Before | After |
|:---:|:---:|
| | |

## ✅ Checklist

- [ ] My code compiles without errors (`./gradlew compileArmDebugKotlin compileAarch64DebugKotlin`)
- [ ] Android Lint passes (`./gradlew lintDebug`) with no new errors
- [ ] I have tested this on a real device or emulator
- [ ] I have tested in both **dark** and **light** theme
- [ ] I have tested in **Incognito mode** (if relevant)
- [ ] I have not broken any existing functionality
- [ ] My changes follow the Kotlin coding conventions
- [ ] I have added comments for any complex logic

## 📝 Additional Notes

<!-- Anything else the reviewer should know? -->
