### PR TITLE
feat: system theme mode, address bar quick actions, context menu background tab, and confirm-exit toggle

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,6 +1,7 @@
 name: PR Check — Lint, Compile & Test
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
   push:

--- a/app/src/main/java/com/rebelroot/omni/MainActivity.kt
+++ b/app/src/main/java/com/rebelroot/omni/MainActivity.kt
@@ -125,9 +125,11 @@ class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val themeState = ThemeStateHolder
+        val isSystemDark = (resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) == android.content.res.Configuration.UI_MODE_NIGHT_YES
+        val effectiveStartupDark = if (themeState.followSystemTheme) isSystemDark else themeState.darkThemeEnabled
         val themeRes = when {
-            themeState.darkThemeEnabled && themeState.amoledMode -> R.style.Theme_OmniBrowser_Amoled
-            themeState.darkThemeEnabled -> R.style.Theme_OmniBrowser_Dark
+            effectiveStartupDark && themeState.amoledMode -> R.style.Theme_OmniBrowser_Amoled
+            effectiveStartupDark -> R.style.Theme_OmniBrowser_Dark
             else -> R.style.Theme_OmniBrowser_Light
         }
         setTheme(themeRes)
@@ -208,6 +210,7 @@ class MainActivity : FragmentActivity() {
         browserViewModel.isAmoledMode = themeState.amoledMode
         browserViewModel.selectedAccentTheme = themeState.accentTheme
         browserViewModel.isDynamicColorEnabled = themeState.dynamicColorEnabled
+        browserViewModel.followSystemTheme = themeState.followSystemTheme
 
         val intentAction = intent?.action
         val rawIntentUrl = intent?.dataString
@@ -248,6 +251,18 @@ class MainActivity : FragmentActivity() {
                 context.resources.updateConfiguration(config, context.resources.displayMetrics)
                 context.createConfigurationContext(config)
             }
+
+            val systemInDark = androidx.compose.foundation.isSystemInDarkTheme()
+            val effectiveDarkTheme = if (browserViewModel.followSystemTheme) systemInDark else browserViewModel.isDarkThemeEnabled
+            val effectiveAmoledMode = if (browserViewModel.followSystemTheme) (browserViewModel.isAmoledMode && systemInDark) else browserViewModel.isAmoledMode
+            val effectiveCreamyMode = if (browserViewModel.followSystemTheme) (browserViewModel.isCreamyMode && !systemInDark) else browserViewModel.isCreamyMode
+
+            LaunchedEffect(effectiveDarkTheme, browserViewModel.followSystemTheme) {
+                if (browserViewModel.followSystemTheme) {
+                    browserViewModel.isDarkThemeEnabled = effectiveDarkTheme
+                }
+            }
+
             CompositionLocalProvider(
                 LocalContext provides localizedContext,
                 LocalConfiguration provides localizedContext.resources.configuration,
@@ -255,10 +270,10 @@ class MainActivity : FragmentActivity() {
                 androidx.activity.compose.LocalOnBackPressedDispatcherOwner provides this@MainActivity
             ) {
                 OmniTheme(
-                    darkTheme = browserViewModel.isDarkThemeEnabled,
+                    darkTheme = effectiveDarkTheme,
                     accentTheme = browserViewModel.selectedAccentTheme,
-                    amoledMode = browserViewModel.isAmoledMode,
-                    creamyMode = browserViewModel.isCreamyMode,
+                    amoledMode = effectiveAmoledMode,
+                    creamyMode = effectiveCreamyMode,
                     dynamicColor = browserViewModel.isDynamicColorEnabled
                 ) {
                     Surface(

--- a/app/src/main/java/com/rebelroot/omni/OmniApplication.kt
+++ b/app/src/main/java/com/rebelroot/omni/OmniApplication.kt
@@ -93,6 +93,7 @@ class OmniApplication : Application() {
                 ThemeStateHolder.amoledMode        = prefs[AMOLED_MODE_KEY]        ?: false
                 ThemeStateHolder.accentTheme       = prefs[ACCENT_THEME_KEY]       ?: "Ocean Blue"
                 ThemeStateHolder.dynamicColorEnabled = prefs[DYNAMIC_COLOR_KEY]    ?: false
+                ThemeStateHolder.followSystemTheme = prefs[FOLLOW_SYSTEM_THEME_KEY] ?: false
             } catch (_: Exception) {
                 // Defaults already applied above; nothing else to do.
             }
@@ -104,6 +105,7 @@ class OmniApplication : Application() {
         val AMOLED_MODE_KEY = booleanPreferencesKey("amoled_mode")
         val DYNAMIC_COLOR_KEY = booleanPreferencesKey("dynamic_color_enabled")
         val ACCENT_THEME_KEY = stringPreferencesKey("accent_theme")
+        val FOLLOW_SYSTEM_THEME_KEY = booleanPreferencesKey("follow_system_theme")
         // UI layout & wallpaper — read synchronously at startup to prevent flash
         val UI_SCALE_KEY            = floatPreferencesKey("ui_scale")
         val HOME_UI_SCALE_KEY       = floatPreferencesKey("home_ui_scale")
@@ -122,6 +124,7 @@ object ThemeStateHolder {
     @Volatile var amoledMode: Boolean = false
     @Volatile var accentTheme: String = "Ocean Blue"
     @Volatile var dynamicColorEnabled: Boolean = false
+    @Volatile var followSystemTheme: Boolean = false
 }
 
 /**

--- a/app/src/main/java/com/rebelroot/omni/browser/BrowserScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/browser/BrowserScreen.kt
@@ -890,8 +890,11 @@ fun BrowserScreen(
             if (viewModel.isExternalIntentLaunch && activity != null) {
                 if (activity.isTaskRoot) activity.finishAndRemoveTask() else activity.finish()
             } else {
-                // On home screen — open exit options sheet immediately (single press)
-                showExitSheet = true
+                if (viewModel.confirmExit) {
+                    showExitSheet = true
+                } else {
+                    if (activity?.isTaskRoot == true) activity.finishAndRemoveTask() else activity?.finish()
+                }
             }
         }
     }

--- a/app/src/main/java/com/rebelroot/omni/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/rebelroot/omni/browser/BrowserViewModel.kt
@@ -176,6 +176,8 @@ class BrowserViewModel : ViewModel() {
         val CUSTOM_SUGGEST_URL_KEY = stringPreferencesKey("custom_suggest_url")
         val CUSTOM_SEARCH_ENGINES_KEY = stringPreferencesKey("custom_search_engines")
         val DARK_THEME_ENABLED_KEY = booleanPreferencesKey("dark_theme_enabled")
+        val FOLLOW_SYSTEM_THEME_KEY = booleanPreferencesKey("follow_system_theme")
+        val CONFIRM_EXIT_KEY = booleanPreferencesKey("confirm_exit_enabled")
         val AMOLED_MODE_KEY = booleanPreferencesKey("amoled_mode")
         val DYNAMIC_COLOR_KEY = booleanPreferencesKey("dynamic_color_enabled")
         val ACCENT_THEME_KEY = stringPreferencesKey("accent_theme")
@@ -603,6 +605,8 @@ class BrowserViewModel : ViewModel() {
     val searchSuggestions = androidx.compose.runtime.mutableStateListOf<String>()
     val historySuggestions = androidx.compose.runtime.mutableStateListOf<HistoryEntry>()
     var isDarkThemeEnabled by mutableStateOf(true)
+    var followSystemTheme by mutableStateOf(false)
+    var confirmExit by mutableStateOf(true)
     var isAmoledMode by mutableStateOf(false)
     var isCreamyMode by mutableStateOf(false)
     var isDynamicColorEnabled by mutableStateOf(false)
@@ -2143,7 +2147,13 @@ class BrowserViewModel : ViewModel() {
         }
     }
 
-    fun createNewTab(context: Context, url: String, groupId: String? = null, isIncognito: Boolean = isIncognitoMode) {
+    fun createNewTab(
+        context: Context,
+        url: String,
+        groupId: String? = null,
+        isIncognito: Boolean = isIncognitoMode,
+        inBackground: Boolean? = null
+    ) {
         val runtime = getGeckoRuntime(context)
         val isJsAllowed = getSitePermissionValue(url, "javascript") == "allow"
         val settings = org.mozilla.geckoview.GeckoSessionSettings.Builder()
@@ -2172,7 +2182,8 @@ class BrowserViewModel : ViewModel() {
             addTabToGroup(tabId, groupId)
         }
         session.open(runtime)
-        if (!openTabsInBackground || tabs.size == 1 || groupId != null) {
+        val shouldOpenInBackground = inBackground ?: (openTabsInBackground && tabs.size > 1 && groupId == null)
+        if (!shouldOpenInBackground || tabs.size == 1) {
             selectTab(newTab.id)
         } else {
             val isIncog = newTab.isIncognito
@@ -3106,6 +3117,8 @@ class BrowserViewModel : ViewModel() {
                 val darkThemePref = getDarkThemePreference(appCtx).first()
                 isDarkThemeEnabled = darkThemePref
                 ThemeStateHolder.darkThemeEnabled = darkThemePref
+                followSystemTheme = getFollowSystemThemePreference(appCtx).first()
+                ThemeStateHolder.followSystemTheme = followSystemTheme
                 updateGeckoColorScheme()
             }
 
@@ -3174,6 +3187,7 @@ class BrowserViewModel : ViewModel() {
                 tabLayoutMode = prefs[TAB_LAYOUT_MODE_KEY] ?: "Grid"
                 autoCloseTabsDays = prefs[AUTO_CLOSE_TABS_DAYS_KEY] ?: 0
                 openTabsInBackground = prefs[OPEN_TABS_IN_BACKGROUND_KEY] ?: false
+                confirmExit = prefs[CONFIRM_EXIT_KEY] ?: true
                 accessibilityTextScale = prefs[ACCESSIBILITY_TEXT_SCALE_KEY] ?: 1.0f
                 accessibilityForceZoom = prefs[ACCESSIBILITY_FORCE_ZOOM_KEY] ?: false
                 accessibilityHighContrast = prefs[ACCESSIBILITY_HIGH_CONTRAST_KEY] ?: false
@@ -3927,6 +3941,38 @@ class BrowserViewModel : ViewModel() {
             if (enabled || forceDarkWebsites) {
                 injectForceDarkCssIfNeeded()
             }
+        }
+    }
+
+    fun getFollowSystemThemePreference(context: Context): Flow<Boolean> {
+        return context.dataStore.data.map { preferences ->
+            preferences[FOLLOW_SYSTEM_THEME_KEY] ?: false
+        }
+    }
+
+    fun saveFollowSystemTheme(context: Context, enabled: Boolean) {
+        viewModelScope.launch {
+            context.dataStore.edit { preferences ->
+                preferences[FOLLOW_SYSTEM_THEME_KEY] = enabled
+            }
+            followSystemTheme = enabled
+            ThemeStateHolder.followSystemTheme = enabled
+            updateGeckoColorScheme()
+        }
+    }
+
+    fun getConfirmExitPreference(context: Context): Flow<Boolean> {
+        return context.dataStore.data.map { preferences ->
+            preferences[CONFIRM_EXIT_KEY] ?: true
+        }
+    }
+
+    fun saveConfirmExit(context: Context, enabled: Boolean) {
+        viewModelScope.launch {
+            context.dataStore.edit { preferences ->
+                preferences[CONFIRM_EXIT_KEY] = enabled
+            }
+            confirmExit = enabled
         }
     }
 

--- a/app/src/main/java/com/rebelroot/omni/browser/PhoneAddressBar.kt
+++ b/app/src/main/java/com/rebelroot/omni/browser/PhoneAddressBar.kt
@@ -646,6 +646,161 @@ fun PhoneAddressBar(
         }
     }
 
+    // ── Address Bar Editing Quick Action Bar (Issue #88) ───────────────────────
+    if (isInputFocused) {
+        val clipboard = remember(context) { context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager }
+        val clipboardText = remember(isInputFocused) {
+            try {
+                clipboard?.primaryClip?.getItemAt(0)?.text?.toString()?.trim()
+            } catch (_: Exception) {
+                null
+            }
+        }
+        val currentText = inputUrl.text.ifEmpty { viewModel.currentUrl }.takeIf { it.isNotEmpty() && it != "about:blank" }
+
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = config.paddingHorizontal)
+                .offset(y = 4.dp),
+            shape = RoundedCornerShape(12.dp),
+            color = if (viewModel.isAmoledMode) Color(0xFF0C0D10) else if (viewModel.isDarkThemeEnabled) Color(0xFF20222A) else Color(0xFFF2F4F7),
+            tonalElevation = 2.dp,
+            shadowElevation = 4.dp,
+            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (!clipboardText.isNullOrBlank()) {
+                    AssistChip(
+                        onClick = {
+                            viewModel.loadUrl(clipboardText)
+                            onInputUrlChange(androidx.compose.ui.text.input.TextFieldValue(clipboardText))
+                            focusManager.clearFocus()
+                            keyboardController?.hide()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Rounded.ContentPaste,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(R.string.address_bar_paste_go),
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium
+                            )
+                        },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                            labelColor = MaterialTheme.colorScheme.primary
+                        ),
+                        border = null
+                    )
+                }
+
+                if (!currentText.isNullOrBlank()) {
+                    AssistChip(
+                        onClick = {
+                            val clip = ClipData.newPlainText("URL", currentText)
+                            clipboard?.setPrimaryClip(clip)
+                            Toast.makeText(context, context.getString(R.string.ctx_link_copied), Toast.LENGTH_SHORT).show()
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Rounded.ContentCopy,
+                                contentDescription = null,
+                                modifier = Modifier.size(15.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(R.string.address_bar_copy),
+                                fontSize = 12.sp
+                            )
+                        },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                            labelColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        border = null
+                    )
+
+                    AssistChip(
+                        onClick = {
+                            val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                                putExtra(Intent.EXTRA_TEXT, currentText)
+                                type = "text/plain"
+                            }
+                            val shareIntent = Intent.createChooser(sendIntent, null)
+                            context.startActivity(shareIntent)
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Rounded.Share,
+                                contentDescription = null,
+                                modifier = Modifier.size(15.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(R.string.address_bar_share),
+                                fontSize = 12.sp
+                            )
+                        },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                            labelColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        border = null
+                    )
+                }
+
+                if (inputUrl.text.isNotEmpty()) {
+                    AssistChip(
+                        onClick = {
+                            onInputUrlChange(androidx.compose.ui.text.input.TextFieldValue(""))
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Rounded.Close,
+                                contentDescription = null,
+                                modifier = Modifier.size(15.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(R.string.address_bar_clear),
+                                fontSize = 12.sp
+                            )
+                        },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                            labelColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        border = null
+                    )
+                }
+            }
+        }
+    }
+
     // ── History Suggestions Dropdown ─────────────────────────────────────────
     if (isInputFocused && viewModel.historySuggestions.isNotEmpty()) {
         val shape = RoundedCornerShape(16.dp)

--- a/app/src/main/java/com/rebelroot/omni/browser/SafariContextMenu.kt
+++ b/app/src/main/java/com/rebelroot/omni/browser/SafariContextMenu.kt
@@ -419,7 +419,21 @@ private fun ActionsCard(
                 iconTint = iconTint,
                 onClick = {
                     viewModel.dismissContextMenu()
-                    viewModel.createNewTab(context, targetUrl)
+                    viewModel.createNewTab(context, targetUrl, inBackground = false)
+                }
+            )
+            HorizontalDivider(color = divColor, thickness = 0.5.dp, modifier = Modifier.padding(start = 16.dp))
+
+            // Open in Background Tab
+            SafariMenuItem(
+                label = stringResource(R.string.ctx_open_background_tab),
+                icon = Icons.Rounded.TabUnselected,
+                textColor = textPrimary,
+                iconTint = iconTint,
+                onClick = {
+                    viewModel.dismissContextMenu()
+                    viewModel.createNewTab(context, targetUrl, inBackground = true)
+                    Toast.makeText(context, context.getString(R.string.ctx_background_tab_opened), Toast.LENGTH_SHORT).show()
                 }
             )
             HorizontalDivider(color = divColor, thickness = 0.5.dp, modifier = Modifier.padding(start = 16.dp))

--- a/app/src/main/java/com/rebelroot/omni/settings/TabsSettingsScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/settings/TabsSettingsScreen.kt
@@ -133,6 +133,19 @@ fun TabsSettingsScreen(
                         textSecondaryColor = textSecondaryColor,
                         accentColor = accentColor
                     )
+                    HorizontalDivider(color = dividerColor, modifier = Modifier.padding(horizontal = 16.dp))
+
+                    // Confirm before exit
+                    SettingsSwitchRow(
+                        icon = Icons.AutoMirrored.Rounded.Logout,
+                        title = stringResource(id = R.string.confirm_exit_title),
+                        subtitle = stringResource(id = R.string.confirm_exit_desc),
+                        checked = viewModel.confirmExit,
+                        onCheckedChange = { viewModel.saveConfirmExit(context, it) },
+                        textPrimaryColor = textPrimaryColor,
+                        textSecondaryColor = textSecondaryColor,
+                        accentColor = accentColor
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/rebelroot/omni/settings/ThemeScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/settings/ThemeScreen.kt
@@ -100,13 +100,15 @@ fun ThemeScreen(
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(stringResource(id = R.string.theme_mode), color = textPrimaryColor, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
                         val themeMode = when {
-                            viewModel.isAmoledMode -> 3
-                            viewModel.isDarkThemeEnabled -> 2
-                            viewModel.isCreamyMode -> 1
-                            else -> 0
+                            viewModel.followSystemTheme -> 0
+                            viewModel.isCreamyMode -> 2
+                            viewModel.isAmoledMode -> 4
+                            viewModel.isDarkThemeEnabled -> 3
+                            else -> 1
                         }
                         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                             val options = listOf(
+                                stringResource(id = R.string.theme_system),
                                 stringResource(id = R.string.theme_light),
                                 stringResource(id = R.string.theme_creamy),
                                 stringResource(id = R.string.theme_dark),
@@ -118,21 +120,28 @@ fun ThemeScreen(
                                     onClick = {
                                         when (index) {
                                             0 -> {
+                                                viewModel.saveFollowSystemTheme(context, true)
+                                            }
+                                            1 -> {
+                                                viewModel.saveFollowSystemTheme(context, false)
                                                 viewModel.saveDarkTheme(context, false)
                                                 viewModel.saveAmoledMode(context, false)
                                                 viewModel.saveCreamyMode(context, false)
                                             }
-                                            1 -> {
+                                            2 -> {
+                                                viewModel.saveFollowSystemTheme(context, false)
                                                 viewModel.saveDarkTheme(context, false)
                                                 viewModel.saveAmoledMode(context, false)
                                                 viewModel.saveCreamyMode(context, true)
                                             }
-                                            2 -> {
+                                            3 -> {
+                                                viewModel.saveFollowSystemTheme(context, false)
                                                 viewModel.saveDarkTheme(context, true)
                                                 viewModel.saveAmoledMode(context, false)
                                                 viewModel.saveCreamyMode(context, false)
                                             }
-                                            3 -> {
+                                            4 -> {
+                                                viewModel.saveFollowSystemTheme(context, false)
                                                 viewModel.saveDarkTheme(context, true)
                                                 viewModel.saveAmoledMode(context, true)
                                                 viewModel.saveCreamyMode(context, false)
@@ -144,7 +153,7 @@ fun ThemeScreen(
                                 ) {
                                     Text(
                                         text = label,
-                                        fontSize = 11.5.sp,
+                                        fontSize = 11.sp,
                                         fontWeight = if (themeMode == index) FontWeight.Bold else FontWeight.Medium,
                                         maxLines = 1,
                                         softWrap = false,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,6 +472,7 @@
     <string name="add_new_engine">Add New</string>
     <string name="no_custom_search_engines">No custom search engines added yet.</string>
     <string name="theme_mode">Theme Mode</string>
+    <string name="theme_system">System</string>
     <string name="theme_light">Light</string>
     <string name="theme_creamy">Creamy</string>
     <string name="theme_dark">Dark</string>
@@ -1703,6 +1704,7 @@
 
     <!-- Safari-style link/image context menu -->
     <string name="ctx_open_new_tab">Open in New Tab</string>
+    <string name="ctx_open_background_tab">Open in Background Tab</string>
     <string name="ctx_open_new_tab_group">Open in New Tab in Group</string>
     <string name="ctx_open_private_tab">Open in Private Tab</string>
     <string name="ctx_copy_link_address">Copy Link Address</string>
@@ -1720,10 +1722,21 @@
     <string name="ctx_clean_link_copied">Clean link copied</string>
     <string name="ctx_download_queued">Download queued</string>
     <string name="ctx_bookmark_saved">Saved to Bookmarks</string>
+    <string name="ctx_background_tab_opened">Tab opened in background</string>
     <string name="ctx_lens_not_installed">Google Lens app not installed</string>
     <string name="ctx_loading_preview">Loading preview…</string>
     <string name="ctx_image_option">Image</string>
     <string name="ctx_link_option">Link</string>
+
+    <!-- Address Bar Actions -->
+    <string name="address_bar_paste_go">Paste &amp; Go</string>
+    <string name="address_bar_copy">Copy</string>
+    <string name="address_bar_share">Share</string>
+    <string name="address_bar_clear">Clear</string>
+
+    <!-- Confirm on Exit Setting -->
+    <string name="confirm_exit_title">Confirm before Exit</string>
+    <string name="confirm_exit_desc">Show exit dialog when pressing Back on the home screen</string>
 
     <!-- Onboarding - Proxy Hub page -->
     <string name="onboarding_title_proxy">Choose Your Privacy Mode</string>


### PR DESCRIPTION
## 📋 Description

This pull request introduces several key UX, navigation, and theme customization improvements across Omni Browser:

1. **System Default Theme Support (Auto Theme)**:
   - Added a "System" option to Theme Mode settings (`follow_system_theme`).
   - Automatically adapts to the Android system dark/light mode dynamically and on cold start without flash.

2. **Address Bar Editing Quick Action Bar**:
   - Added quick action chips when the address bar is focused/editing:
     - **Paste & Go**: Instantly navigates to the clipboard text/URL with one tap.
     - **Copy**: Copies current URL to clipboard.
     - **Share**: Launches the Android system share sheet with the current URL.
     - **Clear**: Quickly clears the address field.

3. **Background Tab Option in Safari Context Menu**:
   - Added an explicit "Open in Background Tab" option to the long-press context menu for links.
   - Enhanced `BrowserViewModel.createNewTab` to handle explicit `inBackground` flags and provide toast feedback.

4. **Confirm before Exit Setting**:
   - Added a toggle under Tabs Settings (`confirm_exit_enabled`, default `true`).
   - Allows users to choose whether to show the multi-choice exit confirmation sheet or exit immediately when pressing Back on the home screen.

## 🔗 Related Issues

- Addresses #70 (Auto theme changing based on system theme)
- Addresses #88 (Editing mode of address bar should have more options)
- Addresses #89 (Fixing new tab opening rule / open in background on long press)
- Addresses #95 (Back gesture to exit browser without confirmation setting)

## 🧪 Type of Change

- [x] ✨ New feature
- [x] 🎨 UI / Style change
- [x] ⚡ Performance improvement

## ✅ Checklist

- [x] My changes follow the Kotlin coding conventions
- [x] I have tested in both **dark** and **light** theme
- [x] I have not broken any existing functionality
- [x] I have added comments for any complex logic