### PR TITLE
Fix:Issues Fixed #113 #120 #118

### DIFF
--- a/app/src/main/java/com/rebelroot/omni/browser/BrowserDialogs.kt
+++ b/app/src/main/java/com/rebelroot/omni/browser/BrowserDialogs.kt
@@ -2387,7 +2387,23 @@ fun ExternalAppRedirectDialog(
             }
             val pm = context.packageManager
             val handlers = try {
-                pm.queryIntentActivities(intent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+                // Use MATCH_ALL instead of MATCH_DEFAULT_ONLY so that
+                // installed apps which are not set as default handlers are
+                // still discovered (fixes intent:// links on Android 11+).
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    pm.queryIntentActivities(
+                        intent,
+                        android.content.pm.PackageManager.ResolveInfoFlags.of(
+                            android.content.pm.PackageManager.MATCH_ALL.toLong()
+                        )
+                    ).filter { it.activityInfo.packageName != context.packageName }
+                } else {
+                    @Suppress("DEPRECATION")
+                    pm.queryIntentActivities(
+                        intent,
+                        android.content.pm.PackageManager.MATCH_ALL
+                    ).filter { it.activityInfo.packageName != context.packageName }
+                }
             } catch (_: Exception) { emptyList() }
 
             when {

--- a/app/src/main/java/com/rebelroot/omni/browser/BrowserViewModel_Session.kt
+++ b/app/src/main/java/com/rebelroot/omni/browser/BrowserViewModel_Session.kt
@@ -1480,14 +1480,14 @@ internal fun getNativeAppHandlers(context: Context, uri: String): List<android.c
                 pm.queryIntentActivities(
                     targetIntent,
                     android.content.pm.PackageManager.ResolveInfoFlags.of(
-                        android.content.pm.PackageManager.MATCH_DEFAULT_ONLY.toLong()
+                        android.content.pm.PackageManager.MATCH_ALL.toLong()
                     )
                 )
             } else {
                 @Suppress("DEPRECATION")
                 pm.queryIntentActivities(
                     targetIntent,
-                    android.content.pm.PackageManager.MATCH_DEFAULT_ONLY
+                    android.content.pm.PackageManager.MATCH_ALL
                 )
             }
         }

--- a/app/src/main/java/com/rebelroot/omni/media/DownloadManagerScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/media/DownloadManagerScreen.kt
@@ -741,7 +741,7 @@ private fun openDownloadedFile(
             }
 
             val pm = context.packageManager
-            val resInfoList = pm.queryIntentActivities(targetIntent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+            val resInfoList = pm.queryIntentActivities(targetIntent, android.content.pm.PackageManager.MATCH_ALL)
             for (resolveInfo in resInfoList) {
                 val packageName = resolveInfo.activityInfo.packageName
                 try {
@@ -822,7 +822,7 @@ private fun shareDownloadedFile(context: Context, file: File, openUri: Uri?) {
         }
 
         val pm = context.packageManager
-        val resInfoList = pm.queryIntentActivities(shareIntent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+        val resInfoList = pm.queryIntentActivities(shareIntent, android.content.pm.PackageManager.MATCH_ALL)
         for (resolveInfo in resInfoList) {
             val packageName = resolveInfo.activityInfo.packageName
             try {

--- a/app/src/main/java/com/rebelroot/omni/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/settings/SettingsScreen.kt
@@ -217,7 +217,7 @@ fun SettingsScreen(
                 RoleManagerHelper.isDefaultBrowser(context)
             } else {
                 val defaultBrowserIntent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://www.google.com"))
-                val resolveInfo = context.packageManager.resolveActivity(defaultBrowserIntent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+                val resolveInfo = context.packageManager.resolveActivity(defaultBrowserIntent, android.content.pm.PackageManager.MATCH_ALL)
                 resolveInfo?.activityInfo?.packageName == context.packageName
             }
         )
@@ -230,7 +230,7 @@ fun SettingsScreen(
             RoleManagerHelper.isDefaultBrowser(context)
         } else {
             val defaultBrowserIntent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://www.google.com"))
-            val resolveInfo = context.packageManager.resolveActivity(defaultBrowserIntent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+            val resolveInfo = context.packageManager.resolveActivity(defaultBrowserIntent, android.content.pm.PackageManager.MATCH_ALL)
             resolveInfo?.activityInfo?.packageName == context.packageName
         }
     }

--- a/app/src/main/java/com/rebelroot/omni/settings/ThemeScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/settings/ThemeScreen.kt
@@ -125,6 +125,11 @@ fun ThemeScreen(
                                         when (index) {
                                             0 -> {
                                                 viewModel.saveFollowSystemTheme(context, true)
+                                                // Reset AMOLED flag when switching to System theme —
+                                                // System theme has no AMOLED variant, and leaving the
+                                                // flag set causes AMOLED colors to leak into the UI
+                                                // (e.g. address bar, cards) even in light mode.
+                                                viewModel.saveAmoledMode(context, false)
                                             }
                                             1 -> {
                                                 viewModel.saveFollowSystemTheme(context, false)

--- a/app/src/main/java/com/rebelroot/omni/tools/passwords/PasswordManagerScreen.kt
+++ b/app/src/main/java/com/rebelroot/omni/tools/passwords/PasswordManagerScreen.kt
@@ -827,7 +827,7 @@ private suspend fun exportPasswordsCsv(context: Context, vaultManager: PasswordV
         val pm = context.packageManager
         val resolvers = pm.queryIntentActivities(
             shareIntent,
-            android.content.pm.PackageManager.MATCH_DEFAULT_ONLY
+            android.content.pm.PackageManager.MATCH_ALL
         )
         for (info in resolvers) {
             try {


### PR DESCRIPTION
Description:
Summary
- Changed MATCH_DEFAULT_ONLY to MATCH_ALL across 6 files
- Fixes intent:// links and external app discovery on Android 11+
- Non-default apps (digital signature, download managers, password managers) are now discovered

Files Changed
- BrowserDialogs.kt ? ExternalAppRedirectDialog intent resolution
- BrowserViewModel_Session.kt ? getNativeAppHandlers query
- DownloadManagerScreen.kt ? open/share downloaded file
- SettingsScreen.kt ? default browser check
- ThemeScreen.kt ? AMOLED flag reset on System theme switch
- PasswordManagerScreen.kt ? CSV export share intent

Issues Fixed
- #113 ? Can't open links in external apps
- #120 ? Browser fails to open installed app via intent:// link
- #118 ? AMOLED to System theme visual leak

